### PR TITLE
logger: drop needless reinitialisation

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -248,8 +248,6 @@ main(int argc, char **argv)
     signal(SIGINT, stop);
     signal(SIGTERM, stop);
 
-    logger_init(o.logger);
-
     q = queue_init();
     if (!q) {
         logger_log("%s %d: Failed to init queue\n", __FILE__, __LINE__);


### PR DESCRIPTION
The signal handler requires an initialised logger so it's optimal to drop the second call rather than the first one.