### PR TITLE
use c11 atomics for lockless state tracking w/o races

### DIFF
--- a/src/utils/helper.c
+++ b/src/utils/helper.c
@@ -182,6 +182,18 @@ parse_connstring(char *conninfo, char **hostname, int *port)
     return res;
 }
 
+bool get_state(const volatile atomic_bool *state)
+{
+    return atomic_load(state);
+}
+
+bool set_state(volatile atomic_bool *state, bool value)
+{
+    bool expected = !value;
+
+    return atomic_compare_exchange_strong(state, &expected, value);
+}
+
 Array
 _delimit_by(char *str, char* delim)
 {

--- a/src/utils/helper.h
+++ b/src/utils/helper.h
@@ -3,6 +3,8 @@
 
 #include <utils/logger.h>
 #include <utils/array.h>
+#include <stdatomic.h>
+#include <stdbool.h>
 #include <stdio.h>
 
 typedef struct Options {
@@ -32,6 +34,9 @@ int options_validate(Options o);
 size_t number_length(long number);
 
 int parse_connstring(char *conninfo, char **hostname, int *port);
+
+bool get_state(const volatile atomic_bool *state);
+bool set_state(volatile atomic_bool *state, bool value);
 
 Array parse_hostinfo_master(char *hostinfo);
 


### PR DESCRIPTION
Use c11 atomic booleans with read-modify-write and load operations to
prevent data races due to concurrent access to run and ready states.
This fixes the three main potential data races reported by helgrind. See
the referenced issue for more context on the races.

In addition the commit modifies state names for clarity.

Fixes: #19