### PR TITLE
use a thread local buffer for logging

### DIFF
--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -14,13 +14,6 @@
 
 #define LOG_BUFFER_SIZE 4096
 
-typedef struct Logger
-{
-    char *buf;
-    char *fname;
-    int fd;
-} Logger;
-
 void logger_init(const char* fname);
 void logger_free();
 void logger_log(const char *fmt, ...);


### PR DESCRIPTION
WIP: This needs a bit more testing. I have only briefly tested it so far and it fixed the issue.
Hence in progress.

Running schaufel under helgrind reports a potential data race
due to concurrent writes to the log buffer:

```
==22079== Possible data race during write of size 1 at 0x6954388 by thread #4
==22079== Locks held: none
==22079==    at 0x4C38DCC: mempcpy (vg_replace_strmem.c:1517)
==22079==    by 0x57B0C35: _IO_default_xsputn (in /usr/x86_64-pc-linux-gnu/lib/libc-2.27.so)
==22079==    by 0x5784D24: vfprintf (in /usr/x86_64-pc-linux-gnu/lib/libc-2.27.so)
==22079==    by 0x57ABFCF: vsnprintf (in /usr/x86_64-pc-linux-gnu/lib/libc-2.27.so)
==22079==    by 0x578BC06: snprintf (in /usr/x86_64-pc-linux-gnu/lib/libc-2.27.so)
==22079==    by 0x406211: buffer_set_timestamp (logger.c:43)
==22079==    by 0x40631D: logger_log (logger.c:62)
==22079==    by 0x404995: stats (main.c:60)
==22079==    by 0x4C33B36: mythread_wrapper (hg_intercepts.c:389)
==22079==    by 0x4E46539: start_thread (in /usr/x86_64-pc-linux-gnu/lib/libpthread-2.27.so)
==22079==    by 0x5829A0E: clone (in /usr/x86_64-pc-linux-gnu/lib/libc-2.27.so)
==22079==
==22079== This conflicts with a previous write of size 1 by thread #2
==22079== Locks held: none
==22079==    at 0x4C38DCC: mempcpy (vg_replace_strmem.c:1517)
==22079==    by 0x57B0C35: _IO_default_xsputn (in /usr/x86_64-pc-linux-gnu/lib/libc-2.27.so)
==22079==    by 0x5784D24: vfprintf (in /usr/x86_64-pc-linux-gnu/lib/libc-2.27.so)
==22079==    by 0x57ABFCF: vsnprintf (in /usr/x86_64-pc-linux-gnu/lib/libc-2.27.so)
==22079==    by 0x578BC06: snprintf (in /usr/x86_64-pc-linux-gnu/lib/libc-2.27.so)
==22079==    by 0x406211: buffer_set_timestamp (logger.c:43)
==22079==    by 0x40631D: logger_log (logger.c:62)
==22079==    by 0x403AA4: file_consumer_consume (file.c:93)
==22079==  Address 0x6954388 is 24 bytes inside a block of size 4,098 alloc'd
==22079==    at 0x4C2FE5E: calloc (vg_replace_malloc.c:711)
==22079==    by 0x406117: logger_init (logger.c:16)
==22079==    by 0x404F3B: main (main.c:233)
==22079==  Block was alloc'd by thread #1
```

The commit changes the storage type of the log buffer to thread local.
In addition this gets rid of the Logger struct which is not necessarily
required or used outside the scope of logger.c

Fixes: #21