### PR TITLE
kafka.c: add message.timeout.ms 30000 to librdkafka conf

### DIFF
--- a/src/kafka.c
+++ b/src/kafka.c
@@ -79,6 +79,13 @@ kafka_producer_meta_init(char *broker, char *topic)
         abort();
     }
 
+    if (rd_kafka_conf_set(conf, "message.timeout.ms","30000",errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        logger_log("%s %d: %s\n", __FILE__, __LINE__, errstr);
+        abort();
+    }
+
+
     rd_kafka_conf_set_dr_msg_cb(conf, dr_msg_cb);
 
     rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));


### PR DESCRIPTION
Whenever a kafka server is restarted, a timeout of 300 seconds
leads to a huge backlog in redis on the backends.

I reduced the producer timeout to 30 seconds and tested on backend-2 (it's still working along there).

Here are logs from backend-1 for comparison purposes:
```
^@Wed Apr 25 11:42:42 2018 added / s: 11244 delivered / s: 11244
^@Wed Apr 25 11:42:47 2018 added / s: 11871 delivered / s: 11871
^@Wed Apr 25 11:42:52 2018 added / s: 11925 delivered / s: 6224 
^@Wed Apr 25 11:42:57 2018 added / s: 11813 delivered / s: 1010 
^@Wed Apr 25 11:43:02 2018 added / s: 3694 delivered / s: 198
^@Wed Apr 25 11:43:07 2018 added / s: 50 delivered / s: 50 
^@Wed Apr 25 11:43:12 2018 added / s: 14 delivered / s: 14 
^@Wed Apr 25 11:43:17 2018 added / s: 4 delivered / s: 4
^@Wed Apr 25 11:43:22 2018 added / s: 1 delivered / s: 1
^@Wed Apr 25 11:43:27 2018 added / s: 0 delivered / s: 0
^@Wed Apr 25 11:43:32 2018 added / s: 0 delivered / s: 0
^@Wed Apr 25 11:43:37 2018 added / s: 0 delivered / s: 0
^@Wed Apr 25 11:43:42 2018 added / s: 0 delivered / s: 0
^@Wed Apr 25 11:43:47 2018 added / s: 0 delivered / s: 0
^@Wed Apr 25 11:43:52 2018 added / s: 0 delivered / s: 0
^@Wed Apr 25 11:43:57 2018 added / s: 0 delivered / s: 0
[...]
^@Wed Apr 25 11:46:57 2018 src/kafka.c 8: Message delivery failed: Local: Message timed out

^@Wed Apr 25 11:46:57 2018 src/kafka.c 8: Message delivery failed: Local: Message timed out

^@Wed Apr 25 11:46:57 2018 src/kafka.c 8: Message delivery failed: Local: Message timed out

^@Wed Apr 25 11:46:57 2018 src/kafka.c 8: Message delivery failed: Local: Message timed out
[...]
```

And here's backend-2:

```
^@Wed Apr 25 11:42:15 2018 added / s: 11467 delivered / s: 11467
^@Wed Apr 25 11:42:20 2018 added / s: 12052 delivered / s: 12052
^@Wed Apr 25 11:42:24 2018 src/kafka.c 8: Message delivery failed: Local: Message timed out

^@Wed Apr 25 11:42:24 2018 src/kafka.c 8: Message delivery failed: Local: Message timed out

^@Wed Apr 25 11:42:24 2018 src/kafka.c 8: Message delivery failed: Local: Message timed out

^@Wed Apr 25 11:42:24 2018 src/kafka.c 8: Message delivery failed: Local: Message timed out
```