### PR TITLE
Kafka consume memcpy

### DIFF
--- a/src/kafka.c
+++ b/src/kafka.c
@@ -242,7 +242,8 @@ void
 kafka_producer_produce(Producer p, Message msg)
 {
     char *buf = (char *) message_get_data(msg);
-    size_t len = strlen(buf);
+    //size_t len = strlen(buf);
+    size_t len = message_get_len(msg);
     rd_kafka_t *rk = ((Meta) p->meta)->rk;
     rd_kafka_topic_t *rkt = ((Meta)p->meta)->rkt;
 retry:
@@ -350,6 +351,7 @@ kafka_consumer_consume(Consumer c, Message msg)
         }
         memcpy(cpy, (char *)rkmessage->payload, (size_t)rkmessage->len);
         message_set_data(msg, cpy);
+        message_set_len(msg, (size_t)rkmessage->len);
         rd_kafka_message_destroy(rkmessage);
     }
     return 0;

--- a/src/kafka.c
+++ b/src/kafka.c
@@ -242,8 +242,9 @@ void
 kafka_producer_produce(Producer p, Message msg)
 {
     char *buf = (char *) message_get_data(msg);
-    //size_t len = strlen(buf);
+    // size_t len = strlen(buf);
     size_t len = message_get_len(msg);
+    logger_log("%s %d: Got message length %lu\n", __FILE__, __LINE__, len);
     rd_kafka_t *rk = ((Meta) p->meta)->rk;
     rd_kafka_topic_t *rkt = ((Meta)p->meta)->rkt;
 retry:
@@ -352,6 +353,7 @@ kafka_consumer_consume(Consumer c, Message msg)
         memcpy(cpy, (char *)rkmessage->payload, (size_t)rkmessage->len);
         message_set_data(msg, cpy);
         message_set_len(msg, (size_t)rkmessage->len);
+        logger_log("%s %d: Set message length to %lu\n", __FILE__, __LINE__, message_get_len(msg));
         rd_kafka_message_destroy(rkmessage);
     }
     return 0;

--- a/src/kafka.c
+++ b/src/kafka.c
@@ -348,7 +348,7 @@ kafka_consumer_consume(Consumer c, Message msg)
             logger_log("%s %d: Failed to calloc: %s\n", __FILE__, __LINE__, strerror(errno));
             abort();
         }
-        strncpy(cpy, (char *)rkmessage->payload, (int)rkmessage->len);
+        memcpy(cpy, (char *)rkmessage->payload, (size_t)rkmessage->len);
         message_set_data(msg, cpy);
         rd_kafka_message_destroy(rkmessage);
     }

--- a/src/kafka.c
+++ b/src/kafka.c
@@ -242,9 +242,7 @@ void
 kafka_producer_produce(Producer p, Message msg)
 {
     char *buf = (char *) message_get_data(msg);
-    // size_t len = strlen(buf);
     size_t len = message_get_len(msg);
-    logger_log("%s %d: Got message length %lu\n", __FILE__, __LINE__, len);
     rd_kafka_t *rk = ((Meta) p->meta)->rk;
     rd_kafka_topic_t *rkt = ((Meta)p->meta)->rkt;
 retry:
@@ -353,7 +351,6 @@ kafka_consumer_consume(Consumer c, Message msg)
         memcpy(cpy, (char *)rkmessage->payload, (size_t)rkmessage->len);
         message_set_data(msg, cpy);
         message_set_len(msg, (size_t)rkmessage->len);
-        logger_log("%s %d: Set message length to %lu\n", __FILE__, __LINE__, message_get_len(msg));
         rd_kafka_message_destroy(rkmessage);
     }
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -124,7 +124,7 @@ consume(void *arg)
             break;
         if (message_get_data(msg) != NULL)
         {
-            queue_add(q, message_get_data(msg), 1);
+            queue_add(q, message_get_data(msg), message_get_len(msg), 1);
             //give up ownership
             message_set_data(msg, NULL);
         }

--- a/src/queue.c
+++ b/src/queue.c
@@ -3,6 +3,7 @@
 typedef struct Message
 {
     void    *data;
+    size_t   datalen;
     int64_t  msgtype;
 } *Message;
 
@@ -26,6 +27,21 @@ message_set_data(Message msg, void *data)
 {
     if (msg)
         msg->data = data;
+}
+
+void
+message_set_len(Message msg, size_t len)
+{
+    if(msg)
+       msg->datalen = len;
+}
+
+size_t
+message_get_len(Message msg)
+{
+    if (msg == NULL)
+        return 0;
+    return msg->datalen;
 }
 
 void

--- a/src/queue.c
+++ b/src/queue.c
@@ -120,7 +120,7 @@ queue_init(void)
 }
 
 int
-queue_add(Queue q, void *data, int64_t msgtype)
+queue_add(Queue q, void *data, size_t datalen, int64_t msgtype)
 {
     MessageList newmsg;
     pthread_mutex_lock(&q->mutex);
@@ -137,6 +137,10 @@ queue_add(Queue q, void *data, int64_t msgtype)
         return ENOMEM;
     }
 
+    if (datalen != 0)
+    {
+        newmsg->msg->datalen = datalen;
+    }
     newmsg->msg->data = data;
     newmsg->msg->msgtype = msgtype;
 
@@ -207,6 +211,7 @@ queue_get(Queue q, Message msg)
     }
 
     msg->data = firstrec->msg->data;
+    msg->datalen = firstrec->msg->datalen;
     msg->msgtype = firstrec->msg->msgtype;
 
     pthread_cond_broadcast(&q->consumer_cond);

--- a/src/queue.h
+++ b/src/queue.h
@@ -22,7 +22,7 @@ void    message_free(Message *msg);
 typedef struct Queue *Queue;
 
 Queue queue_init();
-int  queue_add(Queue q, void *data, long msgtype);
+int  queue_add(Queue q, void *data, size_t datalen, long msgtype);
 int  queue_get(Queue q, Message msg);
 long queue_length(Queue q);
 long queue_added(Queue q);

--- a/src/queue.h
+++ b/src/queue.h
@@ -15,6 +15,8 @@ typedef struct Message *Message;
 Message message_init();
 void   *message_get_data(Message msg);
 void    message_set_data(Message msg, void *data);
+size_t  message_get_len(Message msg);
+void    message_set_len(Message msg, size_t len);
 void    message_free(Message *msg);
 
 typedef struct Queue *Queue;


### PR DESCRIPTION
Messages are blobs, not strings.
This PR aims to fix this problem by extending the data structure of message by datalen.

It's required for using schaufel as an interconnect between kafka clusters (multidc).