### PR TITLE
Producer datalen

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -56,7 +56,6 @@ file_producer_produce(Producer p, Message msg)
 {
     char *line = message_get_data(msg);
     size_t len = message_get_len(msg);
-    //char *newline = "\n";
 
     fwrite(line, len, sizeof(*line),((Meta) p->meta)->fp);
 }

--- a/src/file.c
+++ b/src/file.c
@@ -55,9 +55,10 @@ void
 file_producer_produce(Producer p, Message msg)
 {
     char *line = message_get_data(msg);
-    char *newline = "\n";
-    fwrite(line, strlen(line), sizeof(*line),((Meta) p->meta)->fp);
-    fwrite(newline, 1, 1,((Meta) p->meta)->fp);
+    size_t len = message_get_len(msg);
+    //char *newline = "\n";
+
+    fwrite(line, len, sizeof(*line),((Meta) p->meta)->fp);
 }
 
 void
@@ -93,8 +94,9 @@ file_consumer_consume(Consumer c, Message msg)
         logger_log("%s %d: %s", __FILE__, __LINE__, strerror(errno));
         return -1;
     }
-    line[read-1] = '\0';
+
     message_set_data(msg, line);
+    message_set_len(msg, (size_t) read);
     return 0;
 }
 

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -140,7 +140,15 @@ postgres_producer_produce(Producer p, Message msg)
     Meta m = (Meta)p->meta;
 
     char *buf = (char *) message_get_data(msg);
+    size_t len = message_get_len(msg);
     char *newline = "\n";
+
+    if (buf[len] != '\0')
+    {
+        logger_log("payload doesn't end on null terminator");
+        return;
+    }
+
     char *s = strstr(buf, "\\u0000");
     if (s != NULL)
     {


### PR DESCRIPTION
The aim of this pull request is to handle binary data everywhere (as we can now have binary data).

For postgres (bagger), this means that we only check whether we can assume our data can be handled as a string. All other possible errors are left to postgres's input validator.