### PR TITLE
logger.c: fix off by one in logger_write

### DIFF
--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -49,7 +49,7 @@ static void logger_write(int fd, char *buf, size_t len)
 {
     if (len > LOG_BUFFER_SIZE + 2)
         len = LOG_BUFFER_SIZE + 2;
-    if (write(fd, buf, len) < 0)
+    if (write(fd, buf, (len-1)) < 0)
         fprintf(stderr, "while writing to logfile %s", strerror(errno));
 }
 


### PR DESCRIPTION
Since len's last byte is always a '\0', we don't want to write that, ever.
Now we could just not terminate log_buffer, but for future usage I'd like it to be a terminated string.