### PR TITLE
Commit intervals

### DIFF
--- a/src/postgres.c
+++ b/src/postgres.c
@@ -108,7 +108,7 @@ _commit_worker(void *meta)
         /* if count > 0 it implies that copy == 1,
          * therefore it is safe to commit data */
         if((!((*m)->commit_iter)) && ((*m)->count > 0)) {
-            logger_log("%s %d: Autocommiting", __FILE__, __LINE__);
+            logger_log("%s %d: Autocommiting %d entries", __FILE__, __LINE__, (*m)->count);
             _commit(m);
         }
 

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -92,8 +92,8 @@ _commit_worker(void *meta)
 {
     Meta *m = (Meta *) meta;
 
-    #if __linux__
-    prctl(PR_SET_NAME, "commit worker");
+    #ifdef PR_SET_NAME
+    prctl(PR_SET_NAME, "commit_worker");
     #endif
 
     while(42)

--- a/src/postgres.h
+++ b/src/postgres.h
@@ -6,6 +6,8 @@
 #include <producer.h>
 #include <stdlib.h>
 #include <libpq-fe.h>
+#include <pthread.h>
+#include <sys/prctl.h>
 
 typedef struct Producer *Producer;
 

--- a/src/postgres.h
+++ b/src/postgres.h
@@ -7,9 +7,7 @@
 #include <stdlib.h>
 #include <libpq-fe.h>
 #include <pthread.h>
-#ifdef __linux__
 #include <sys/prctl.h>
-#endif
 
 typedef struct Producer *Producer;
 

--- a/src/postgres.h
+++ b/src/postgres.h
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <libpq-fe.h>
 #include <pthread.h>
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif
 
 typedef struct Producer *Producer;
 


### PR DESCRIPTION
The postgres producer (which will soon be renamed bagger producer) doesn't end copy unless there are 2000 entries reached.
This generates three problems:
 - the data table in a schema may not be altered until copy end (I mostly avoid this problem already with some extra sql)
 - data appears with hours of delay in some cases
 - in case of a dead database handle, it also crashes with hours of delay
