### PR TITLE
src/kafka.c: destroy all rdkafka error messages

### DIFF
--- a/src/kafka.c
+++ b/src/kafka.c
@@ -310,35 +310,32 @@ kafka_consumer_consume(Consumer c, Message msg)
 
         if (rkmessage->err)
         {
-            if (rkmessage->err == RD_KAFKA_RESP_ERR__PARTITION_EOF)
+            switch(rkmessage->err)
             {
-                /*
-                 * Debug messages
-                logger_log("Consumer reached end of %s [%"PRId32"] "
-                    "message queue at offset %"PRId64"\n",
-                    rd_kafka_topic_name(rkmessage->rkt),
-                    rkmessage->partition, rkmessage->offset);
-                */
-                return 0;
-            }
-            if (rkmessage->rkt)
-            {
-                logger_log("%% Consume error for "
-                    "topic \"%s\" [%"PRId32"] "
-                    "offset %"PRId64": %s\n",
-                    rd_kafka_topic_name(rkmessage->rkt),
-                    rkmessage->partition,
-                    rkmessage->offset,
-                    rd_kafka_message_errstr(rkmessage));
-            }
-            else
-                logger_log("%% Consumer error: %s: %s\n",
-                    rd_kafka_err2str(rkmessage->err),
-                    rd_kafka_message_errstr(rkmessage));
+                case RD_KAFKA_RESP_ERR__PARTITION_EOF:
+                    break;
 
-            if (rkmessage->err == RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION ||
-                rkmessage->err == RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC)
-                abort();
+                case RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION:
+                case RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC:
+                    abort();
+                    break;
+
+                default:
+                    if (rkmessage->rkt)
+                    {
+                        logger_log("%% Consume error for "
+                            "topic \"%s\" [%"PRId32"] "
+                            "offset %"PRId64": %s\n",
+                            rd_kafka_topic_name(rkmessage->rkt),
+                            rkmessage->partition,
+                            rkmessage->offset,
+                            rd_kafka_message_errstr(rkmessage));
+                    }
+                    else
+                        logger_log("%% Consumer error: %s: %s\n",
+                            rd_kafka_err2str(rkmessage->err),
+                            rd_kafka_message_errstr(rkmessage));
+            }
 
             rd_kafka_message_destroy(rkmessage);
             return 0;


### PR DESCRIPTION
Turns out we did create a memory leak after all.

I rearranged the code so that rkmessage is destroyed if you leave the case statement.