### PR TITLE
postgres.c: avoid race condition on m->copy

### DIFF
--- a/src/postgres.c
+++ b/src/postgres.c
@@ -230,6 +230,7 @@ postgres_producer_produce(Producer p, Message msg)
 
     char *lit = PQescapeLiteral(m->conn_master, buf, strlen(buf));
 
+    pthread_mutex_lock(&m->commit_mutex);
     if (m->copy == 0)
     {
         m->res = PQexec(m->conn_master, m->cpycmd);
@@ -273,7 +274,6 @@ postgres_producer_produce(Producer p, Message msg)
     if (m->conninfo_replica)
         PQputCopyData(m->conn_replica, newline, 1);
 
-    pthread_mutex_lock(&m->commit_mutex);
     m->count = m->count + 1;
     if (m->count == 2000)
     {


### PR DESCRIPTION
This race is ultra-rare (can't be reproduced with millions of inserts). That means with our workload, we hit it every other hour.
It causes the postgres connection to go out of sync, because one might put copy messages while copy is being finished.