### PR TITLE
Makefile: removed debug, moved functionality to debug.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ INSTALL ?= install
 
 CC ?= gcc
 LD = $(CC)
-CFLAGS ?= -Wall -std=c11 -Wextra -Werror -pedantic -O2 -march=native
+CFLAGS += -Wall -Wextra -pedantic
+CFLAGS += -std=c11
 CFLAGS += -D_POSIX_C_SOURCE=200809L
 CFLAGS += -D_SCHAUFEL_VERSION='"$(SCHAUFEL_VERSION)"'
 LIB = -lpthread -lhiredis -lrdkafka -lpq

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,7 @@ release: before_release $(OBJ) out_release
 test: clean_release before_release $(OBJ_TEST) $(OBJ_BIN_TEST)
 
 before_release:
-	test -d bin || mkdir -p bin
-	test -d obj || mkdir -p obj
-	test -d obj/utils || mkdir -p obj/utils
+	mkdir -p obj/utils bin
 
 clean: clean_release
 

--- a/debug.sh
+++ b/debug.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 CFLAGS='-Wall -std=c11 -Wextra -Werror -pedantic -Og -ggdb'
-make clean && make test && make
+make test && make

--- a/debug.sh
+++ b/debug.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-CFLAGS='-Wall -std=c11 -Wextra -Werror -pedantic -Og -ggdb'
-make test && make

--- a/debug.sh
+++ b/debug.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+CFLAGS='-Wall -std=c11 -Wextra -Werror -pedantic -Og -ggdb'
+make clean && make test && make

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+CFLAGS='-Werror -Og -ggdb'
+make test && make

--- a/t/file_consumer_test.c
+++ b/t/file_consumer_test.c
@@ -11,7 +11,7 @@ main(void)
     Options o;
     memset(&o, '\0', sizeof(o));
     o.in_file = "sample/dummy_file";
-    logger_init("log/test");
+    logger_init("sample/dummy_log");
     Message msg = message_init();
     Consumer c = consumer_init('f', &o);
     char *string;

--- a/t/queue_test.c
+++ b/t/queue_test.c
@@ -7,7 +7,7 @@ main(void)
     Queue q = queue_init();
     Message msg = message_init();
     char *data = "moep";
-    queue_add(q, data, 1);
+    queue_add(q, data, sizeof(data), 1);
     queue_get(q, msg);
     pretty_assert(strncmp(data, (char *) message_get_data(msg), 4) == 0);
     queue_free(&q);

--- a/t/queue_test.c
+++ b/t/queue_test.c
@@ -7,9 +7,9 @@ main(void)
     Queue q = queue_init();
     Message msg = message_init();
     char *data = "moep";
-    queue_add(q, data, sizeof(data), 1);
+    queue_add(q, data, strlen(data), 1);
     queue_get(q, msg);
-    pretty_assert(strncmp(data, (char *) message_get_data(msg), 4) == 0);
+    pretty_assert(strncmp(data, (char *) message_get_data(msg), strlen(data)) == 0);
     queue_free(&q);
     message_free(&msg);
     return 0;


### PR DESCRIPTION
The old makefile ignored system defined compilers,linkers, CFLAGS and always installed debug schaufel.
This means every bin package has been created without optimization for cpu architecture and without any optimization flags.
I've therefore removed the entire debug codepath in our makefile and rather made CFLAGS definable by environment.
The function of the debug codepath is now rather delegated to debug.sh which simply calls the makefile with appropriate debug flags.