### PR TITLE
Headers refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ CC ?= gcc
 LD = $(CC)
 CFLAGS += -Wall -Wextra -pedantic
 CFLAGS += -std=c11
-CFLAGS += -D_POSIX_C_SOURCE=200809L
+CFLAGS += -D_XOPEN_SOURCE=700
 CFLAGS += -D_SCHAUFEL_VERSION='"$(SCHAUFEL_VERSION)"'
-CFLAGS += -D_BSD_SOURCE
+CFLAGS += -D_DEFAULT_SOURCE
 LIB = -lpthread -lhiredis -lrdkafka -lpq -lconfig -ljson-c
 INC = -Isrc/
 

--- a/src/consumer.c
+++ b/src/consumer.c
@@ -1,4 +1,9 @@
-#include <consumer.h>
+#include "consumer.h"
+#include "dummy.h"
+#include "file.h"
+#include "kafka.h"
+#include "redis.h"
+
 
 Consumer
 consumer_init(char kind, config_setting_t *config)

--- a/src/consumer.h
+++ b/src/consumer.h
@@ -1,13 +1,10 @@
 #ifndef _SCHAUFEL_CONSUMER_H_
 #define _SCHAUFEL_CONSUMER_H_
 
-#include <dummy.h>
-#include <file.h>
-#include <kafka.h>
-#include <queue.h>
-#include <redis.h>
-#include <utils/helper.h>
-#include <utils/scalloc.h>
+#include <libconfig.h>
+
+#include "queue.h"
+
 
 typedef struct Consumer *Consumer;
 

--- a/src/dummy.c
+++ b/src/dummy.c
@@ -1,8 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "dummy.h"
 #include "utils/helper.h"
+#include "utils/logger.h"
 #include "utils/scalloc.h"
 
 

--- a/src/dummy.c
+++ b/src/dummy.c
@@ -1,4 +1,10 @@
-#include <dummy.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "dummy.h"
+#include "utils/helper.h"
+#include "utils/scalloc.h"
+
 
 Producer
 dummy_producer_init(UNUSED config_setting_t *config)

--- a/src/dummy.h
+++ b/src/dummy.h
@@ -1,13 +1,11 @@
 #ifndef _SCHAUFEL_DUMMY_H_
 #define _SCHAUFEL_DUMMY_H_
 
-#include <consumer.h>
-#include <queue.h>
-#include <producer.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include "consumer.h"
+#include "producer.h"
+#include "queue.h"
+#include "validator.h"
 
-typedef struct Producer *Producer;
 
 Producer dummy_producer_init(config_setting_t *config);
 
@@ -15,15 +13,11 @@ void dummy_producer_free(Producer *p);
 
 void dummy_producer_produce(Producer p, Message msg);
 
-typedef struct Consumer *Consumer;
-
 Consumer dummy_consumer_init();
 
 void dummy_consumer_free(Consumer *c);
 
 int dummy_consumer_consume(Consumer c, Message msg);
-
-typedef struct Validator *Validator;
 
 Validator dummy_validator_init();
 

--- a/src/exports.c
+++ b/src/exports.c
@@ -1,5 +1,13 @@
-#include <exports.h>
-#include <utils/postgres.h>
+#include <libpq-fe.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <json-c/json.h>
+
+#include "exports.h"
+#include "utils/helper.h"
+#include "utils/postgres.h"
+#include "utils/scalloc.h"
+
 
 typedef struct Needles *Needles;
 typedef struct Needles {

--- a/src/exports.c
+++ b/src/exports.c
@@ -1,10 +1,15 @@
+#include <errno.h>
 #include <libpq-fe.h>
 #include <pthread.h>
 #include <stdlib.h>
+#include <string.h>
 #include <json-c/json.h>
+#include <arpa/inet.h>
 
 #include "exports.h"
+#include "utils/config.h"
 #include "utils/helper.h"
+#include "utils/logger.h"
 #include "utils/postgres.h"
 #include "utils/scalloc.h"
 

--- a/src/exports.c
+++ b/src/exports.c
@@ -5,7 +5,6 @@
 #include <string.h>
 #include <json-c/json.h>
 #include <arpa/inet.h>
-#include <endian.h>
 
 #include "exports.h"
 #include "utils/config.h"
@@ -13,6 +12,7 @@
 #include "utils/logger.h"
 #include "utils/postgres.h"
 #include "utils/scalloc.h"
+#include "utils/endian.h"
 
 
 typedef struct Needles *Needles;

--- a/src/exports.c
+++ b/src/exports.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <json-c/json.h>
 #include <arpa/inet.h>
+#include <endian.h>
 
 #include "exports.h"
 #include "utils/config.h"

--- a/src/exports.h
+++ b/src/exports.h
@@ -1,18 +1,13 @@
 #ifndef _SCHAUFEL_EXPORTS_H_
 #define _SCHAUFEL_EXPORTS_H_
 
-#include <consumer.h>
-#include <utils/logger.h>
-#include <producer.h>
-#include <stdlib.h>
-#include <libpq-fe.h>
-#include <pthread.h>
-#include <json-c/json.h>
-#include <queue.h>
-#include <sys/prctl.h>
-#include <endian.h>
+#include <libconfig.h>
 
-typedef struct Producer *Producer;
+#include "producer.h"
+#include "consumer.h"
+#include "validator.h"
+#include "queue.h"
+
 
 Producer exports_producer_init(config_setting_t *config);
 
@@ -20,15 +15,11 @@ void exports_producer_free(Producer *p);
 
 void exports_producer_produce(Producer p, Message msg);
 
-typedef struct Consumer *Consumer;
-
 Consumer exports_consumer_init(config_setting_t *config);
 
 void exports_consumer_free(Consumer *c);
 
 int exports_consumer_consume(Consumer c, Message msg);
-
-typedef struct Validator *Validator;
 
 Validator exports_validator_init();
 

--- a/src/file.c
+++ b/src/file.c
@@ -1,6 +1,10 @@
-#include <file.h>
 #include <errno.h>
 #include <stdio.h>
+
+#include "file.h"
+#include "utils/logger.h"
+#include "utils/scalloc.h"
+
 
 /* TODO:
  * lots of error handling

--- a/src/file.c
+++ b/src/file.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "file.h"
 #include "utils/logger.h"

--- a/src/file.h
+++ b/src/file.h
@@ -1,14 +1,11 @@
 #ifndef _SCHAUFEL_FILE_H_
 #define _SCHAUFEL_FILE_H_
 
-#include <consumer.h>
-#include <producer.h>
-#include <queue.h>
-#include <stdlib.h>
-#include <utils/logger.h>
-#include <validator.h>
+#include "consumer.h"
+#include "producer.h"
+#include "queue.h"
+#include "validator.h"
 
-typedef struct Producer *Producer;
 
 Producer file_producer_init(config_setting_t *config);
 
@@ -16,15 +13,11 @@ void file_producer_free(Producer *p);
 
 void file_producer_produce(Producer p, Message msg);
 
-typedef struct Consumer *Consumer;
-
 Consumer file_consumer_init(config_setting_t *config);
 
 void file_consumer_free(Consumer *c);
 
 int file_consumer_consume(Consumer c, Message msg);
-
-typedef struct Validator *Validator;
 
 Validator file_validator_init();
 

--- a/src/kafka.c
+++ b/src/kafka.c
@@ -1,5 +1,10 @@
-#include <kafka.h>
-#include <errno.h>
+#include <librdkafka/rdkafka.h>
+#include <stdbool.h>
+
+#include "kafka.h"
+#include "utils/helper.h"
+#include "utils/scalloc.h"
+
 
 static void
 dr_msg_cb (UNUSED rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, UNUSED void *opaque)

--- a/src/kafka.c
+++ b/src/kafka.c
@@ -1,8 +1,12 @@
+#include <errno.h>
 #include <librdkafka/rdkafka.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "kafka.h"
+#include "utils/config.h"
 #include "utils/helper.h"
+#include "utils/logger.h"
 #include "utils/scalloc.h"
 
 

--- a/src/kafka.h
+++ b/src/kafka.h
@@ -1,14 +1,11 @@
 #ifndef _SCHAUFEL_KAFKA_H_
 #define _SCHAUFEL_KAFKA_H_
 
-#include <consumer.h>
-#include <librdkafka/rdkafka.h>
-#include <utils/logger.h>
-#include <producer.h>
-#include <queue.h>
-#include <stdlib.h>
+#include "consumer.h"
+#include "producer.h"
+#include "queue.h"
+#include "validator.h"
 
-typedef struct Producer *Producer;
 
 Producer kafka_producer_init(config_setting_t *config);
 
@@ -16,15 +13,12 @@ void kafka_producer_free(Producer *p);
 
 void kafka_producer_produce(Producer p, Message msg);
 
-typedef struct Consumer *Consumer;
-
 Consumer kafka_consumer_init(config_setting_t *config);
 
 void kafka_consumer_free(Consumer *c);
 
 int kafka_consumer_consume(Consumer c, Message msg);
 
-typedef struct Validator *Validator;
 Validator kafka_validator_init();
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,11 +6,13 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include "consumer.h"
 #include "producer.h"
 #include "utils/config.h"
 #include "utils/helper.h"
+#include "utils/logger.h"
 #include "utils/options.h"
 #include "utils/scalloc.h"
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,14 +1,19 @@
-#include <utils/logger.h>
-#include <queue.h>
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
 #include <stdatomic.h>
 #include <stdbool.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <signal.h>
-#include <producer.h>
-#include <utils/helper.h>
-#include <version.h>
-#include <utils/scalloc.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/time.h>
+
+#include "consumer.h"
+#include "producer.h"
+#include "utils/config.h"
+#include "utils/helper.h"
+#include "utils/options.h"
+#include "utils/scalloc.h"
+
 
 /* Schaufel keeps track of consume and produce states.
  *

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -1,4 +1,3 @@
-#include <errno.h>
 #include <libpq-fe.h>
 #include <pthread.h>
 #include <string.h>

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -1,8 +1,13 @@
+#include <errno.h>
 #include <libpq-fe.h>
 #include <pthread.h>
+#include <string.h>
 
 #include "postgres.h"
+#include "utils/array.h"
+#include "utils/config.h"
 #include "utils/helper.h"
+#include "utils/logger.h"
 #include "utils/postgres.h"
 #include "utils/scalloc.h"
 

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -1,5 +1,11 @@
-#include <postgres.h>
-#include <utils/postgres.h>
+#include <libpq-fe.h>
+#include <pthread.h>
+
+#include "postgres.h"
+#include "utils/helper.h"
+#include "utils/postgres.h"
+#include "utils/scalloc.h"
+
 
 char *
 _connectinfo(const char *host)

--- a/src/postgres.h
+++ b/src/postgres.h
@@ -1,18 +1,11 @@
 #ifndef _SCHAUFEL_POSTGRES_H_
 #define _SCHAUFEL_POSTGRES_H_
 
-#include <consumer.h>
-#include <queue.h>
-#include <utils/logger.h>
-#include <producer.h>
-#include <stdlib.h>
-#include <libpq-fe.h>
-#include <pthread.h>
-#include <sys/prctl.h>
-#include <queue.h>
-#include <validator.h>
+#include "consumer.h"
+#include "producer.h"
+#include "queue.h"
+#include "validator.h"
 
-typedef struct Producer *Producer;
 
 Producer postgres_producer_init(config_setting_t *config);
 
@@ -20,15 +13,11 @@ void postgres_producer_free(Producer *p);
 
 void postgres_producer_produce(Producer p, Message msg);
 
-typedef struct Consumer *Consumer;
-
 Consumer postgres_consumer_init(char *host);
 
 void postgres_consumer_free(Consumer *c);
 
 int postgres_consumer_consume(Consumer c, Message msg);
-
-typedef struct Validator *Validator;
 
 Validator postgres_validator_init();
 

--- a/src/producer.c
+++ b/src/producer.c
@@ -1,4 +1,11 @@
-#include <producer.h>
+#include "dummy.h"
+#include "exports.h"
+#include "file.h"
+#include "kafka.h"
+#include "postgres.h"
+#include "producer.h"
+#include "redis.h"
+
 
 Producer
 producer_init(char kind, config_setting_t *config)

--- a/src/producer.h
+++ b/src/producer.h
@@ -1,23 +1,18 @@
 #ifndef _SCHAUFEL_PRODUCER_H_
 #define _SCHAUFEL_PRODUCER_H_
 
-#include <dummy.h>
-#include <exports.h>
-#include <file.h>
-#include <kafka.h>
-#include <postgres.h>
-#include <queue.h>
-#include <redis.h>
-#include <utils/helper.h>
-#include <utils/scalloc.h>
+#include <libconfig.h>
+
+#include "queue.h"
+
 
 typedef struct Producer *Producer;
 
-typedef struct Producer {
+struct Producer {
     void (*produce) (Producer p, Message msg);
     void (*producer_free)(Producer *p);
     void *meta;
-} *Producer;
+};
 
 Producer producer_init(char kind, config_setting_t *config);
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,4 +1,9 @@
-#include <queue.h>
+#include <errno.h>
+#include <pthread.h>
+#include <sys/time.h>
+
+#include "queue.h"
+
 
 typedef struct Message
 {

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <sys/time.h>
+#include <stdint.h>
 
 #include "queue.h"
 

--- a/src/queue.h
+++ b/src/queue.h
@@ -2,6 +2,7 @@
 #define _SCHAUFEL_QUEUE_H_
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #define MAX_QUEUE_SIZE 100000
 
@@ -17,7 +18,7 @@ void    message_free(Message *msg);
 typedef struct Queue *Queue;
 
 Queue queue_init();
-int  queue_add(Queue q, void *data, size_t datalen, long msgtype);
+int  queue_add(Queue q, void *data, size_t datalen, int64_t msgtype);
 int  queue_get(Queue q, Message msg);
 long queue_length(Queue q);
 long queue_added(Queue q);

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,12 +1,7 @@
 #ifndef _SCHAUFEL_QUEUE_H_
 #define _SCHAUFEL_QUEUE_H_
 
-#include <pthread.h>
-#include <stdint.h>
 #include <stdlib.h>
-#include <string.h>
-#include <errno.h>
-#include <sys/time.h>
 
 #define MAX_QUEUE_SIZE 100000
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "redis.h"
+#include "utils/config.h"
 #include "utils/logger.h"
 #include "utils/helper.h"
 #include "utils/scalloc.h"

--- a/src/redis.c
+++ b/src/redis.c
@@ -1,4 +1,13 @@
-#include <redis.h>
+#include <errno.h>
+#include <hiredis/hiredis.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "redis.h"
+#include "utils/logger.h"
+#include "utils/helper.h"
+#include "utils/scalloc.h"
+
 
 typedef struct Meta {
     redisContext *c;

--- a/src/redis.h
+++ b/src/redis.h
@@ -1,14 +1,11 @@
 #ifndef _SCHAUFEL_REDIS_H_
 #define _SCHAUFEL_REDIS_H_
 
-#include <consumer.h>
-#include <hiredis/hiredis.h>
-#include <utils/logger.h>
-#include <producer.h>
-#include <stdlib.h>
-#include <validator.h>
+#include "consumer.h"
+#include "producer.h"
+#include "queue.h"
+#include "validator.h"
 
-typedef struct Producer *Producer;
 
 Producer redis_producer_init(config_setting_t *config);
 
@@ -16,15 +13,11 @@ void redis_producer_free(Producer *p);
 
 void redis_producer_produce(Producer p, Message msg);
 
-typedef struct Consumer *Consumer;
-
 Consumer redis_consumer_init(config_setting_t *config);
 
 void redis_consumer_free(Consumer *c);
 
 int redis_consumer_consume(Consumer c, Message msg);
-
-typedef struct Validator *Validator;
 
 Validator redis_validator_init();
 #endif

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -1,4 +1,6 @@
 #include <stdio.h>
+#include <string.h>
+
 
 #define RESET       "\033[0m"
 #define BLACK       "\033[30m"          /* Black */

--- a/src/utils/array.c
+++ b/src/utils/array.c
@@ -1,4 +1,5 @@
 #include <utils/array.h>
+#include "utils/scalloc.h"
 
 typedef struct Array
 {

--- a/src/utils/array.c
+++ b/src/utils/array.c
@@ -1,12 +1,18 @@
-#include <utils/array.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "utils/array.h"
+#include "utils/logger.h"
 #include "utils/scalloc.h"
 
-typedef struct Array
+
+struct Array
 {
     char   **payload;
     size_t   len;
     size_t   used;
-} *Array;
+};
 
 Array
 array_init(size_t len)

--- a/src/utils/array.h
+++ b/src/utils/array.h
@@ -1,12 +1,10 @@
 #ifndef _SCHAUFEL_UTILS_ARRAY_H
 #define _SCHAUFEL_UTILS_ARRAY_H
 
-#include <stdio.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-#include <utils/logger.h>
-#include <utils/options.h>
+#include <stddef.h>
+
+
+typedef struct Array *Array;
 
 Array array_init(size_t len);
 

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -1,4 +1,10 @@
-#include <utils/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "utils/config.h"
+#include "utils/logger.h"
+#include "validator.h"
+
 
 int get_thread_count(config_t* config, int type)
 {

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -4,15 +4,11 @@
 #define SCHAUFEL_TYPE_CONSUMER 1
 #define SCHAUFEL_TYPE_PRODUCER 2
 
-
 #include <libconfig.h>
-#include <search.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <stdbool.h>
-#include <utils/options.h>
-#include <utils/logger.h>
-#include <validator.h>
+
+#include "utils/options.h"
+
 
 void read_config(config_t *config, char *cfile);
 

--- a/src/utils/endian.h
+++ b/src/utils/endian.h
@@ -1,0 +1,15 @@
+#ifndef _SCHAUFEL_UTILS_ENDIAN_H
+#define _SCHAUFEL_UTILS_ENDIAN_H
+
+#if defined(__linux__)
+#include <endian.h>
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) \
+    || defined(__NetBSD__) || defined(__DragonFly__)
+#include <sys/endian.h>
+#endif
+
+#endif

--- a/src/utils/helper.c
+++ b/src/utils/helper.c
@@ -1,4 +1,9 @@
-#include <utils/helper.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "utils/array.h"
+#include "utils/helper.h"
+
 
 size_t number_length(long number)
 {

--- a/src/utils/helper.h
+++ b/src/utils/helper.h
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+
 int options_validate(Options o);
 
 size_t number_length(long number);

--- a/src/utils/helper.h
+++ b/src/utils/helper.h
@@ -1,13 +1,10 @@
 #ifndef _SCHAUFEL_UTILS_HELPER_H_
 #define _SCHAUFEL_UTILS_HELPER_H_
 
-#include <utils/options.h>
-#include <utils/logger.h>
-#include <utils/array.h>
-#include <search.h>
 #include <stdatomic.h>
 #include <stdbool.h>
-#include <stdio.h>
+
+#include "utils/options.h"
 
 
 int options_validate(Options o);

--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -1,4 +1,8 @@
-#include <utils/logger.h>
+#include <stdatomic.h>
+
+#include "utils/helper.h"
+#include "utils/logger.h"
+
 
 static int log_fd;
 static char *log_fname;

--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -1,5 +1,13 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
 #include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
 
+#include "utils/config.h"
 #include "utils/helper.h"
 #include "utils/logger.h"
 

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -1,18 +1,10 @@
 #ifndef _SCHAUFEL_LOGGER_H_
 #define _SCHAUFEL_LOGGER_H_
 
-#include <unistd.h>
+#include <libconfig.h>
+#include <stdbool.h>
 #include <stdio.h>
-#include <fcntl.h>
-#include <string.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <time.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <utils/config.h>
-#include <search.h>
+
 
 #define LOG_BUFFER_SIZE 4096
 #define FORMAT_PRINTF(x,y) __attribute__((format (printf,(x),(y))))

--- a/src/utils/options.h
+++ b/src/utils/options.h
@@ -1,7 +1,8 @@
 #ifndef _SCHAUFEL_UTILS_OPTIONS_H
 #define _SCHAUFEL_UTILS_OPTIONS_H
 
-typedef struct Array *Array;
+#include "utils/array.h"
+
 
 typedef struct Options {
     char *config;

--- a/src/utils/postgres.c
+++ b/src/utils/postgres.c
@@ -1,5 +1,8 @@
 #include <arpa/inet.h>
 #include <unistd.h>
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
 
 #include "utils/logger.h"
 #include "utils/postgres.h"

--- a/src/utils/postgres.c
+++ b/src/utils/postgres.c
@@ -1,4 +1,9 @@
-#include <utils/postgres.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include "utils/logger.h"
+#include "utils/postgres.h"
+
 
 void
 commit(Meta *m)

--- a/src/utils/postgres.h
+++ b/src/utils/postgres.h
@@ -3,8 +3,6 @@
 
 #include <libpq-fe.h>
 #include <pthread.h>
-#include <utils/logger.h>
-#include <arpa/inet.h>
 
 #define PQ_COPY_TEXT   0
 #define PQ_COPY_CSV    1

--- a/src/utils/scalloc.c
+++ b/src/utils/scalloc.c
@@ -1,4 +1,10 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "utils/logger.h"
 #include "utils/scalloc.h"
+
 
 void *
 scalloc(size_t n, size_t s, char *file, size_t line)

--- a/src/utils/scalloc.h
+++ b/src/utils/scalloc.h
@@ -1,7 +1,6 @@
 #ifndef _SCHAUFEL_UTILS_SCALLOC_H
 #define _SCHAUFEL_UTILS_SCALLOC_H
 
-#include "utils/logger.h"
 
 void *scalloc(size_t n, size_t s, char *file, size_t line);
 #define SCALLOC(n, s) scalloc(( n), (s), __FILE__, __LINE__)

--- a/src/validator.c
+++ b/src/validator.c
@@ -1,4 +1,10 @@
-#include <validator.h>
+#include "dummy.h"
+#include "exports.h"
+#include "file.h"
+#include "kafka.h"
+#include "postgres.h"
+#include "redis.h"
+#include "validator.h"
 
 Validator
 validator_init(const char* kind)

--- a/src/validator.h
+++ b/src/validator.h
@@ -1,20 +1,15 @@
 #ifndef _SCHAUFEL_VALIDATOR_H
 #define _SCHAUFEL_VALIDATOR_H
 
-#include <dummy.h>
-#include <exports.h>
-#include <file.h>
-#include <kafka.h>
-#include <postgres.h>
-#include <queue.h>
-#include <redis.h>
-#include <utils/helper.h>
+#include <libconfig.h>
 #include <stdbool.h>
 
-typedef struct Validator {
+typedef struct Validator *Validator;
+
+struct Validator {
     bool (*validate_consumer) (config_setting_t* config);
     bool (*validate_producer) (config_setting_t* config);
-} *Validator;
+};
 
 Validator validator_init(const char* kind);
 #endif

--- a/t/array.c
+++ b/t/array.c
@@ -1,5 +1,6 @@
-#include <test/test.h>
-#include <utils/array.h>
+#include "test/test.h"
+#include "utils/array.h"
+
 
 int
 main(void)

--- a/t/config_merge_test.c
+++ b/t/config_merge_test.c
@@ -1,8 +1,10 @@
 #include <stdio.h>
-#include <test/test.h>
-#include <utils/config.h>
-#include <utils/options.h>
 #include <stdbool.h>
+
+#include "test/test.h"
+#include "utils/config.h"
+#include "utils/options.h"
+
 
 bool lookup_str(config_t* config, const char *string, const char *test)
 {

--- a/t/dummy_consumer_test.c
+++ b/t/dummy_consumer_test.c
@@ -1,7 +1,10 @@
-#include <queue.h>
-#include <consumer.h>
 #include <stdio.h>
 #include <test/test.h>
+#include <string.h>
+
+#include "queue.h"
+#include "consumer.h"
+
 
 int
 main(void)

--- a/t/dummy_consumer_test.c
+++ b/t/dummy_consumer_test.c
@@ -1,9 +1,9 @@
 #include <stdio.h>
-#include <test/test.h>
 #include <string.h>
 
-#include "queue.h"
 #include "consumer.h"
+#include "queue.h"
+#include "test/test.h"
 
 
 int

--- a/t/dummy_producer_test.c
+++ b/t/dummy_producer_test.c
@@ -1,6 +1,8 @@
-#include <queue.h>
-#include <producer.h>
 #include <stdio.h>
+
+#include "queue.h"
+#include "producer.h"
+
 
 int
 main(void)

--- a/t/file_consumer_test.c
+++ b/t/file_consumer_test.c
@@ -1,11 +1,12 @@
-#include <queue.h>
-#include <consumer.h>
 #include <stdio.h>
-#include <test/test.h>
-#include <utils/logger.h>
-#include <utils/helper.h>
-#include <utils/config.h>
-#include <utils/options.h>
+
+#include "consumer.h"
+#include "queue.h"
+#include "test/test.h"
+#include "utils/config.h"
+#include "utils/helper.h"
+#include "utils/logger.h"
+#include "utils/options.h"
 
 int
 main(void)

--- a/t/parse_connstring.c
+++ b/t/parse_connstring.c
@@ -1,6 +1,9 @@
-#include <test/test.h>
-#include <utils/helper.h>
+#include <stdlib.h>
 #include <stdio.h>
+
+#include "test/test.h"
+#include "utils/helper.h"
+
 
 int
 main(void)

--- a/t/parse_hostinfo.c
+++ b/t/parse_hostinfo.c
@@ -1,5 +1,7 @@
-#include <test/test.h>
-#include <utils/helper.h>
+#include "test/test.h"
+#include "utils/array.h"
+#include "utils/helper.h"
+
 
 int
 main(void)

--- a/t/queue_test.c
+++ b/t/queue_test.c
@@ -1,5 +1,8 @@
 #include <test/test.h>
-#include <queue.h>
+#include <string.h>
+
+#include "queue.h"
+
 
 int
 main(void)

--- a/t/queue_test.c
+++ b/t/queue_test.c
@@ -1,7 +1,7 @@
-#include <test/test.h>
 #include <string.h>
 
 #include "queue.h"
+#include "test/test.h"
 
 
 int


### PR DESCRIPTION
This PR sorts out headers. Mainly two things have been done:

1. `#include <...>` were replaced with `#include "..."` for local headers;
2. Headers that were used only in `.c` files were moved from `.h` files to `.c` files.