### PR TITLE
Replace deprecated _BSD_SOURCE macro with _DEFAULT_SOURCE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CFLAGS += -Wall -Wextra -pedantic
 CFLAGS += -std=c11
 CFLAGS += -D_POSIX_C_SOURCE=200809L
 CFLAGS += -D_SCHAUFEL_VERSION='"$(SCHAUFEL_VERSION)"'
-CFLAGS += -D_BSD_SOURCE
+CFLAGS += -D_DEFAULT_SOURCE
 LIB = -lpthread -lhiredis -lrdkafka -lpq -lconfig -ljson-c
 INC = -Isrc/
 


### PR DESCRIPTION
As of glibc 2.19 _BSD_SOURCE macro is deprecated and causing annoying warnings:

```
cc -Isrc/ -Wall -Wextra -pedantic -std=c11 -D_POSIX_C_SOURCE=200809L -D_SCHAUFEL_VERSION='"0.5"' -D_BSD_SOURCE -c src/utils/array.c -o obj/utils/array.o
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:27,
                 from src/utils/array.h:4,
                 from src/utils/array.c:1:
/usr/include/features.h:185:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
```
(see #58). It is now recommended to use _DEFAULT_SOURCE.