### PR TITLE
{exports,queue}.c: added headers for standard conforming libcs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ CC ?= gcc
 LD = $(CC)
 CFLAGS += -Wall -Wextra -pedantic
 CFLAGS += -std=c11
-CFLAGS += -D_POSIX_C_SOURCE=200809L
+CFLAGS += -D_XOPEN_SOURCE=700
 CFLAGS += -D_SCHAUFEL_VERSION='"$(SCHAUFEL_VERSION)"'
-CFLAGS += -D_BSD_SOURCE
+CFLAGS += -D_DEFAULT_SOURCE
 LIB = -lpthread -lhiredis -lrdkafka -lpq -lconfig -ljson-c
 INC = -Isrc/
 

--- a/src/exports.c
+++ b/src/exports.c
@@ -5,7 +5,6 @@
 #include <string.h>
 #include <json-c/json.h>
 #include <arpa/inet.h>
-#include <endian.h>
 
 #include "exports.h"
 #include "utils/config.h"
@@ -13,6 +12,7 @@
 #include "utils/logger.h"
 #include "utils/postgres.h"
 #include "utils/scalloc.h"
+#include "utils/endian.h"
 
 
 typedef struct Needles *Needles;

--- a/src/exports.c
+++ b/src/exports.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <json-c/json.h>
 #include <arpa/inet.h>
+#include <endian.h>
 
 #include "exports.h"
 #include "utils/config.h"

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <pthread.h>
 #include <sys/time.h>
+#include <stdint.h>
 
 #include "queue.h"
 

--- a/src/queue.h
+++ b/src/queue.h
@@ -2,6 +2,7 @@
 #define _SCHAUFEL_QUEUE_H_
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #define MAX_QUEUE_SIZE 100000
 
@@ -17,7 +18,7 @@ void    message_free(Message *msg);
 typedef struct Queue *Queue;
 
 Queue queue_init();
-int  queue_add(Queue q, void *data, size_t datalen, long msgtype);
+int  queue_add(Queue q, void *data, size_t datalen, int64_t msgtype);
 int  queue_get(Queue q, Message msg);
 long queue_length(Queue q);
 long queue_added(Queue q);

--- a/src/utils/endian.h
+++ b/src/utils/endian.h
@@ -1,0 +1,15 @@
+#ifndef _SCHAUFEL_UTILS_ENDIAN_H
+#define _SCHAUFEL_UTILS_ENDIAN_H
+
+#if defined(__linux__)
+#include <endian.h>
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) \
+    || defined(__NetBSD__) || defined(__DragonFly__)
+#include <sys/endian.h>
+#endif
+
+#endif

--- a/src/utils/postgres.c
+++ b/src/utils/postgres.c
@@ -1,5 +1,8 @@
 #include <arpa/inet.h>
 #include <unistd.h>
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
 
 #include "utils/logger.h"
 #include "utils/postgres.h"


### PR DESCRIPTION
These are the only cases I noticed where includes break on non glibc machines.
I didn't check out whether all source files are reasonably self contained, that's for the next version of schaufel.