### PR TITLE
Simplify logging

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -23,7 +23,7 @@ file_meta_init(const char *fname, char *options)
     m->fp = fopen(fname, options);
     if (m->fp == NULL)
     {
-        logger_log("%s %d: %s %s", __FILE__, __LINE__, fname, strerror(errno));
+        log("%s %s", fname, strerror(errno));
         abort();
     }
     return m;
@@ -33,7 +33,7 @@ void
 file_meta_free(Meta *m)
 {
     if ( fclose((*m)->fp) != 0)
-        logger_log("%s %d: %s", __FILE__, __LINE__, strerror(errno));
+        log(strerror(errno));
     free(*m);
     *m = NULL;
 }
@@ -91,7 +91,7 @@ file_consumer_consume(Consumer c, Message msg)
     ssize_t read;
     if ((read = getline(&line, &bufsize, ((Meta) c->meta)->fp)) == -1)
     {
-        logger_log("%s %d: %s", __FILE__, __LINE__, strerror(errno));
+        log(strerror(errno));
         return -1;
     }
 

--- a/src/kafka.c
+++ b/src/kafka.c
@@ -14,7 +14,7 @@ static void
 dr_msg_cb (UNUSED rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, UNUSED void *opaque)
 {
     if (rkmessage->err)
-        logger_log("%s %d: Message delivery failed: %s\n", __FILE__, __LINE__, rd_kafka_err2str(rkmessage->err));
+        log("Message delivery failed: %s\n", rd_kafka_err2str(rkmessage->err));
 }
 
 static void
@@ -75,13 +75,13 @@ kafka_producer_meta_init(const char *broker, const char *topic)
 
     if (rd_kafka_conf_set(conf, "compression.codec", "lz4", errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
     {
-        logger_log("%s %d: %s", __FILE__, __LINE__, errstr);
+        log(errstr);
         abort();
     }
 
     if (rd_kafka_conf_set(conf, "queue.buffering.max.ms","1000",errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
     {
-        logger_log("%s %d: %s\n", __FILE__, __LINE__, errstr);
+        log(errstr);
         abort();
     }
 
@@ -90,12 +90,12 @@ kafka_producer_meta_init(const char *broker, const char *topic)
     rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
     if (!rk)
     {
-        logger_log("%s %d: Failed to create new producer: %s\n", __FILE__, __LINE__, errstr);
+        log("Failed to create new producer: %s", errstr);
         abort();
     }
     if (rd_kafka_brokers_add(rk, broker) == 0)
     {
-        logger_log("%s %d: Failed to add broker: %s\n", __FILE__, __LINE__, broker);
+        log("Failed to add broker: %s", broker);
         abort();
     }
 
@@ -103,9 +103,7 @@ kafka_producer_meta_init(const char *broker, const char *topic)
 
     if (!rkt)
     {
-        logger_log("%s %d: Failed to create topic object: %s\n",
-            __FILE__,
-            __LINE__,
+        log("Failed to create topic object: %s",
             rd_kafka_err2str(rd_kafka_last_error()));
         rd_kafka_destroy(rk);
         abort();
@@ -132,29 +130,29 @@ kafka_consumer_meta_init(const char *broker, const char *topic, const char *grou
 
     if (rd_kafka_conf_set(conf, "group.id", groupid, errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
     {
-        logger_log("%s %d: %s", __FILE__, __LINE__, errstr);
+        log(errstr);
         abort();
     }
 
     if (rd_kafka_topic_conf_set(topic_conf, "offset.store.method","broker",errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
     {
-        logger_log("%s %d: %s\n", __FILE__, __LINE__, errstr);
+        log(errstr);
         abort();
     }
     if (rd_kafka_topic_conf_set(topic_conf, "enable.auto.commit","true",errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
     {
-        logger_log("%s %d: %s\n", __FILE__, __LINE__, errstr);
+        log(errstr);
         abort();
     }
     if (rd_kafka_topic_conf_set(topic_conf, "auto.commit.interval.ms","10",errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
     {
-        logger_log("%s %d: %s\n", __FILE__, __LINE__, errstr);
+        log(errstr);
         abort();
     }
 
     if (rd_kafka_topic_conf_set(topic_conf, "auto.offset.reset","latest",errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
     {
-        logger_log("%s %d: %s\n", __FILE__, __LINE__, errstr);
+        log(errstr);
         abort();
     }
 
@@ -165,7 +163,7 @@ kafka_consumer_meta_init(const char *broker, const char *topic, const char *grou
     rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
     if (!rk)
     {
-        logger_log("%s %d: Failed to create new consumer: %s\n", __FILE__, __LINE__, errstr);
+        log("Failed to create new consumer: %s", errstr);
         abort();
     }
 
@@ -178,7 +176,8 @@ kafka_consumer_meta_init(const char *broker, const char *topic, const char *grou
     rkt = rd_kafka_topic_new(rk, topic, NULL);
     if (!rkt)
     {
-        logger_log("%s %d: Failed to create topic object: %s\n", __FILE__, __LINE__, rd_kafka_err2str(rd_kafka_last_error()));
+        log("Failed to create topic object: %s",
+            rd_kafka_err2str(rd_kafka_last_error()));
         rd_kafka_destroy(rk);
         abort();
     }
@@ -190,10 +189,9 @@ kafka_consumer_meta_init(const char *broker, const char *topic, const char *grou
 
     if ((err = rd_kafka_subscribe(rk, topics)))
     {
-            fprintf(stderr,
-                    "%% Failed to start consuming topics: %s\n",
-                    rd_kafka_err2str(err));
-            abort();
+        logger_log("%% Failed to start consuming topics: %s",
+                   rd_kafka_err2str(err));
+        abort();
     }
     m->rk = rk;
     m->rkt = rkt;
@@ -263,12 +261,9 @@ retry:
         }
         else
         {
-            logger_log(
-                "%s %d Failed to produce to topic %s: %s\n",
-                __FILE__, __LINE__,
+            log("Failed to produce to topic %s: %s",
                 rd_kafka_topic_name(rkt),
-                rd_kafka_err2str(rd_kafka_last_error())
-            );
+                rd_kafka_err2str(rd_kafka_last_error()));
         }
     }
     rd_kafka_poll(rk, 0);

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include "utils/logger.h"
 #include "utils/options.h"
 #include "utils/scalloc.h"
+#include "version.h"
 
 
 /* Schaufel keeps track of consume and produce states.
@@ -114,14 +115,14 @@ consume(void *config)
 
     if (msg == NULL)
     {
-        logger_log("%s %d: could not init message", __FILE__, __LINE__);
+        log("could not init message");
         return NULL;
     }
     Consumer c = consumer_init(*consumer_type,
         (config_setting_t *) config);
     if (c == NULL)
     {
-        logger_log("%s %d: could not init consumer", __FILE__, __LINE__);
+        log("could not init consumer");
         return NULL;
     }
 
@@ -157,7 +158,7 @@ produce(void *config)
         (config_setting_t *) config);
     if (p == NULL)
     {
-        logger_log("%s %d: could not init producer", __FILE__, __LINE__);
+        log("could not init producer");
         return NULL;
     }
 
@@ -336,7 +337,7 @@ main(int argc, char **argv)
 
     q = queue_init();
     if (!q) {
-        logger_log("%s %d: Failed to init queue\n", __FILE__, __LINE__);
+        log("Failed to init queue");
         abort();
     }
 

--- a/src/redis.c
+++ b/src/redis.c
@@ -38,13 +38,13 @@ redis_meta_init(const char *host, const char *topic, size_t pipe_max)
     {
         if (m->c)
         {
-            logger_log("%s %d: redis connection failed: %s", __FILE__, __LINE__, m->c->errstr);
+            log("redis connection failed: %s", m->c->errstr);
             redisFree(m->c);
             abort();
         }
         else
         {
-            logger_log("%s %d: allocate failed", __FILE__, __LINE__);
+            log("allocate failed");
         }
     }
 
@@ -70,8 +70,8 @@ redis_meta_get_reply(Meta m)
     if ((ret = redisGetReply(m->c, (void *)&reply)) == REDIS_OK)
         m->reply = reply;
     else
-        logger_log("%s %d: %s %s", __FILE__, __LINE__, m->c->errstr,
-                   m->c->err == REDIS_ERR_IO ? strerror(errno) : "");
+        log("%s %s", m->c->errstr,
+            m->c->err == REDIS_ERR_IO ? strerror(errno) : "");
     return ret;
 }
 
@@ -163,7 +163,7 @@ redis_consumer_handle_reply(const redisReply *reply, Message msg)
     {
         char *result = calloc(reply->element[1]->len + 1, sizeof(*result));
         if(!result) {
-            logger_log("%s %d: Failed to calloc!", __FILE__, __LINE__);
+            logger_log("Failed to calloc!");
             abort();
         }
         memcpy(result, reply->element[1]->str, reply->element[1]->len);

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -8,11 +8,13 @@
 
 #define LOG_BUFFER_SIZE 4096
 #define FORMAT_PRINTF(x,y) __attribute__((format (printf,(x),(y))))
+#define log(...) logger_log_fileinfo(__FILE__, __LINE__, __VA_ARGS__)
 
 bool get_logger_state();
 bool logger_validate(config_setting_t *config);
 void logger_init(config_setting_t *config);
 void logger_free();
+void logger_log_fileinfo(const char *file, size_t line, const char *fmt, ...);
 void logger_log(const char *fmt, ...) FORMAT_PRINTF(1,2);
 
 #endif


### PR DESCRIPTION
This is just a proof of concept, actual macro name may be changed in final version. But the general idea is to simplify the way logging is implemented. Namely it requires developer to specify `__FILE__` and `__LINE__` macros manually. In this PR i introduce `logger_log_fileinfo` function similar to `logger_log` with the only difference that it accepts extra file and line number arguments. Also `log` macro was introduced which automatically puts file and line number in the function call. This design particularly allows to use `log` without any format arguments like this:

```
log("some error message");
```

I left the original `logger_log` func calls in the places where `__FILE__` and `__LINE__` hadn't been used. Probably it makes sense to make them uniform and use the new `log` macro instead.