### PR TITLE
Default options for kafka and postgres providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CFLAGS += -Wall -Wextra -pedantic
 CFLAGS += -std=c11
 CFLAGS += -D_XOPEN_SOURCE=700
 CFLAGS += -D_SCHAUFEL_VERSION='"$(SCHAUFEL_VERSION)"'
-CFLAGS += -D_DEFAULT_SOURCE
+CFLAGS += -D_GNU_SOURCE
 LIB = -lpthread -lhiredis -lrdkafka -lpq -lconfig -ljson-c
 INC = -Isrc/
 

--- a/man/schaufel.conf.5
+++ b/man/schaufel.conf.5
@@ -121,6 +121,44 @@ producers = (
 .PP
 Next to the standard producers, there are two special kinds. The postgres
 with replication (\fBbagger\fR) kind, and the \fBexports\fR type.
+.SS kafka
+Kafka is a producer and consumer to Apache \fIkafka\fR, using \fIlibrdkafka\fR.
+Only the message payload is forwarded, all metadata is discarded.
+.PP
+The miminum configuration for a producer is a broker and a topic, for the
+consumer a broker, topic and group id are required.
+Further options can be set if the groups \fIkafka_options\fR and
+\fItopic_options\fR are added to the config file. The names of options
+correspond to librdkafka and that is where they are documented.
+.PP
+Because of limitations in libconfigs grammar, dots are replaced by underscores
+in the naming scheme.
+.RS
+.PP
+consumers = (
+    {
+        type = "kafka";
+        threads = 10;
+        broker = "kafka-1.host.name";
+        topic = "schaufel_queue";
+        group = "schaufel_queue_1";
+        kafka_options = {
+            partition_assignment_strategy = "roundrobin";
+        };
+    });
+.PP
+producers = (
+    {
+        type = "kafka";
+        threads = 10;
+        broker = "kafka-1.host.name";
+        topic = "schaufel_new_queue";
+        topic_options = {
+            compression_codec = "zstd";
+        };
+    });
+
+.RE
 .SS bagger
 Bagger is essentially a producer of the \fIpostgres\fR type. Through the
 \fIhost\fR string one can define a list of postgres databases and message

--- a/src/kafka.c
+++ b/src/kafka.c
@@ -75,7 +75,8 @@ static void kafka_set_option(const char *key, const char *value, void *arg)
     rd_kafka_conf_t    *conf = (rd_kafka_conf_t *) arg;
     rd_kafka_conf_res_t res;
 
-    strcpy(buf, key);
+    strncpy(buf, key, sizeof(buf));
+    buf[sizeof(buf) - 1] = '\0';
     /* kafka options use `.` (dot) as a separator */
     replace_char(buf, '_', '.');
 
@@ -94,7 +95,8 @@ static void kafka_topic_set_option(const char *key, const char *value, void *arg
     rd_kafka_topic_conf_t  *topic_conf = (rd_kafka_topic_conf_t *) arg;
     rd_kafka_conf_res_t     res;
 
-    strcpy(buf, key);
+    strncpy(buf, key, sizeof(buf));
+    buf[sizeof(buf) - 1] = '\0';
     replace_char(buf, '_', '.');
 
     res = rd_kafka_topic_conf_set(topic_conf, buf, value, errstr, sizeof(errstr));

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include "utils/logger.h"
 #include "utils/options.h"
 #include "utils/scalloc.h"
+#include "version.h"
 
 
 /* Schaufel keeps track of consume and produce states.
@@ -78,8 +79,8 @@ NORETURN void
 print_version()
 {
     printf("schaufel version: "
-            _SCHAUFEL_VERSION
-            "\n");
+           _SCHAUFEL_VERSION
+           "\n");
     exit(0);
 }
 

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -46,7 +46,8 @@ _connectinfo(const char *host, const char *dbname, const char *user)
 static char *
 _cpycmd(const char *host, const char *generation, postgres_format fmt)
 {
-    char *cpycmd;
+    const char *format = fmt == POSTGRES_JSON ? "text" : "csv";
+    char       *cpycmd;
 
     if (host == NULL)
         return NULL;
@@ -67,11 +68,11 @@ _cpycmd(const char *host, const char *generation, postgres_format fmt)
     }
 
     if (fmt == POSTGRES_CSV)
-        cpycmd = SSPRINTF("COPY %s FROM STDIN (FORMAT CSV)", generation);
+        cpycmd = SSPRINTF("COPY %s FROM STDIN (FORMAT %s)", generation, format);
     else
     {
-        cpycmd = SSPRINTF("COPY %s_%d_%s.data FROM STDIN (FORMAT CSV)",
-                          hostname, port, generation);
+        cpycmd = SSPRINTF("COPY %s_%d_%s.data FROM STDIN (FORMAT %s)",
+                          hostname, port, generation, format);
     }
 
     free(hostname);

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -27,7 +27,7 @@ struct pg_parameters {
 };
 
 char *
-_connectinfo(const char *host, const char *user, const char *dbname)
+_connectinfo(const char *host, const char *dbname, const char *user)
 {
     if (host == NULL)
         return NULL;

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -423,13 +423,16 @@ config_setting_t *config_create_path(config_setting_t *parent,
             /* not a group? */
             if (config_setting_type(found) != CONFIG_TYPE_GROUP)
             {
-                /*
-                 * Currently by the time when this function is used the logger
-                 * is already initialized. When it's not the case anymore
-                 * the way of logging error here must be changed.
-                 */
-                logger_log("%s %d: `%s` is not a settings group",
-                           __FILE__, __LINE__, prefix);
+                if(get_logger_state())
+                {
+                    logger_log("%s %d: `%s` is not a settings group",
+                               __FILE__, __LINE__, prefix);
+                }
+                else
+                {
+                    fprintf(stderr,"%s %d: `%s` is not a settings group",
+                            __FILE__, __LINE__, prefix);
+                }
                 abort();
             }
 

--- a/src/utils/config.c
+++ b/src/utils/config.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -405,8 +406,9 @@ config_setting_t *config_create_path(config_setting_t *parent,
     char    buf[512];
     char   *prefix = buf;
 
-    /* TODO: put an assert on strlen <= 512 */
-    strcpy(buf, path);
+    assert(strlen(path) < 512);
+    strncpy(buf, path, sizeof(buf));
+    buf[sizeof(buf) - 1] = '\0';
 
     while ((sep = strchr(prefix, PATH_SEPARATOR)) != NULL)
     {

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -9,6 +9,8 @@
 
 #include "utils/options.h"
 
+typedef void (*group_func)(const char *key, const char *value, void *arg);
+
 
 void read_config(config_t *config, char *cfile);
 
@@ -20,6 +22,14 @@ bool config_validate(config_t *config);
 
 char* module_to_string(int module);
 
+void config_group_apply(const config_setting_t *options, group_func func, void *arg);
+
+config_setting_t *config_create_path(config_setting_t *parent,
+                                     const char *path,
+                                     int type);
+
+void config_set_default_string(config_setting_t *parent, const char *path,
+   const char *value);
 
 /* Macros to abstract config parsing
  * Check for existance of a config item */
@@ -39,5 +49,4 @@ bool conf_is_list(config_setting_t *conf,
     conf_get_member(conf, name, __FILE__, __LINE__, err)
 #define CONF_IS_LIST(conf, err) \
     conf_is_list(conf, __FILE__, __LINE__, err)
-
 #endif

--- a/src/utils/scalloc.c
+++ b/src/utils/scalloc.c
@@ -23,28 +23,3 @@ scalloc(size_t n, size_t s, char *file, size_t line)
     return ret;
 }
 
-/*
- * ssprintf
- *      Allocates the exact amount of memory for the formatted string and
- *      returns formatted string. Returned memory must be released manually
- *      by calling SFREE or free.
- */
-char *
-ssprintf(const char *fmt, char *file, size_t line, ...)
-{
-    va_list     args1, args2;
-    size_t      len;
-    char       *str;
-
-    va_start(args1, line);
-    va_copy(args2, args1);
-    len = vsnprintf(NULL, 0, fmt, args1);
-    va_end(args1);
-
-    /* +1 for terminal \0 symbol */
-    str = scalloc(1, len + 1, file, line);
-    vsprintf(str, fmt, args2);
-    va_end(args2);
-
-    return str;
-}

--- a/src/utils/scalloc.c
+++ b/src/utils/scalloc.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -20,4 +21,30 @@ scalloc(size_t n, size_t s, char *file, size_t line)
         abort();
     }
     return ret;
+}
+
+/*
+ * ssprintf
+ *      Allocates the exact amount of memory for the formatted string and
+ *      returns formatted string. Returned memory must be released manually
+ *      by calling SFREE or free.
+ */
+char *
+ssprintf(const char *fmt, char *file, size_t line, ...)
+{
+    va_list     args1, args2;
+    size_t      len;
+    char       *str;
+
+    va_start(args1, line);
+    va_copy(args2, args1);
+    len = vsnprintf(NULL, 0, fmt, args1);
+    va_end(args1);
+
+    /* +1 for terminal \0 symbol */
+    str = scalloc(1, len + 1, file, line);
+    vsprintf(str, fmt, args2);
+    va_end(args2);
+
+    return str;
 }

--- a/src/utils/scalloc.h
+++ b/src/utils/scalloc.h
@@ -5,9 +5,6 @@
 void *scalloc(size_t n, size_t s, char *file, size_t line);
 #define SCALLOC(n, s) scalloc(( n), (s), __FILE__, __LINE__)
 
-char *ssprintf(const char *fmt, char *file, size_t line, ...);
-#define SSPRINTF(fmt, ...) ssprintf(fmt, __FILE__, __LINE__, __VA_ARGS__) 
-
 #define SFREE(e) \
     do { \
         free(e); \

--- a/src/utils/scalloc.h
+++ b/src/utils/scalloc.h
@@ -5,6 +5,9 @@
 void *scalloc(size_t n, size_t s, char *file, size_t line);
 #define SCALLOC(n, s) scalloc(( n), (s), __FILE__, __LINE__)
 
+char *ssprintf(const char *fmt, char *file, size_t line, ...);
+#define SSPRINTF(fmt, ...) ssprintf(fmt, __FILE__, __LINE__, __VA_ARGS__) 
+
 #define SFREE(e) \
     do { \
         free(e); \


### PR DESCRIPTION
Here is the first approach to the problem of setting defaults to the data providers. Three new functions were introduced to manipulate configs:

```c
config_setting_t *config_create_path(config_setting_t *parent,
                                     const char *path,
                                     int type)
```
Create a new setting node using the provided `path`. The path is specified as a string in form of `"path/to/my/setting"` (i.e. a slash separated list of nested setting groups). If path doesn't exist the function will automatically create all the nodes. If it does then the function returns `NULL`.

```c
void config_set_default_string(config_setting_t *parent,
                               const char *path,
                               const char *value)
```
Creates a new string setting node and sets a value to it. Again if setting doesn't exists then function returns a pointer to the created setting; otherwise `NULL`.

```c
void config_group_apply(const config_setting_t *options, group_func func, void *arg)
```
Applies `func` to each member of the setting group. `group_func` is defined as
```c
void (*group_func)(const char *key, const char *value, void *arg)
```
In this PR it is used to set default kafka config options and kafka topic options. See `kafka_topic_set_option()` as an example.

Another potentially useful new function and a corresponding macro:
```c
char *ssprintf(const char *fmt, char *file, size_t line, ...);
#define SSPRINTF(fmt, ...) ssprintf(fmt, __FILE__, __LINE__, __VA_ARGS__)
```
Allocates exact amount of memory needed to accommodate formatted string and returns this string.


While working on kafka options i ran into an issue that `libconfig` syntax doesn't allow key names containing `.` (dots). This follows from `libconfig`'s grammar.

**scanner.l**:
```
name              [A-Za-z\*][-A-Za-z0-9_\*]*
...
{name}            { yylval->sval = yytext; return(TOK_NAME); }
```
(surprisingly it allows `*` symbol)

**grammar.y**:
```
setting:
  TOK_NAME
  { ... }
  TOK_EQUALS value setting_terminator
  ;
```
At the same time `librdkafka`'s option names contain dots in them (e.g. `queue.buffering.max.ms`). To workaround this i currently replace all the dots with underscores (and this is how user should specify them as well) and convert them back before passing them to `librdkafka`.