### PR TITLE
src/postgres.c: cpycmd support for fqdns

### DIFF
--- a/src/postgres.c
+++ b/src/postgres.c
@@ -48,7 +48,7 @@ _cpycmd(const char *host, const char *generation)
     char *ptr = hostname;
     while(*ptr)
     {
-        if(*ptr == '-')
+        if((*ptr == '-') || (*ptr == '.'))
         {
             *ptr = '_';
         }


### PR DESCRIPTION
This PR transforms `.` to `_`, so fqdns can be compatible with postgres schemas.