### PR TITLE
Exports filters

### DIFF
--- a/man/schaufel.conf.5
+++ b/man/schaufel.conf.5
@@ -232,7 +232,34 @@ producers = (
         topic = "data";
         jpointers = (
             [ "/error", "text", "discard_true", "exists" ],
-            [ "/data/customer", "text", "store_true", "substr", "Doe" ],
+            [ "/data/customer", "text", "store_true", "substr", "doe" ],
+            "/data/request/http_response",
+            "/data/request/body/0",
+            ["/timestamp", "timestamp"],
+        );
+    } );
+.RE
+.PP
+Because arrays are not human readable, a filter can also be declared in
+a group. Default values can be omitted. This example is functionally
+equivalent to the last:
+producers = (
+    {
+        type = "exports"
+        threads = 1;
+        topic = "data";
+        jpointers = (
+            {
+                jpointer = "/error";
+                action = "discard_true";
+                filter = "exists";
+            },
+            {
+                jpointer = "/data/customer";
+                action = "store_true";
+                filter = "substr";
+                data = "doe";
+            },
             "/data/request/http_response",
             "/data/request/body/0",
             ["/timestamp", "timestamp"],

--- a/man/schaufel.conf.5
+++ b/man/schaufel.conf.5
@@ -217,7 +217,7 @@ CfCB | CfCB | CfCB.
 filter@description@data
 =
 noop@return true@-
-exists@does the json_pointer point to an existing field@string
+exists@does the json_pointer point to an existing field@-
 match@compare result of json_pointer against a string@string
 substr@find string in result@string
 .TE

--- a/man/schaufel.conf.5
+++ b/man/schaufel.conf.5
@@ -153,6 +153,8 @@ and dereferences it into columns of a type. At the moment only
 Dereferencing is done via a list of json pointers called \fIjpointers\fR.
 These pointers confirm to \fIRFC 6901\fR. If a type other than text is
 required, an array can be used to specify a type.
+If a json pointer does not return data, the field is transformed to a
+postgres null.
 .RS
 .PP
 producers = (
@@ -164,8 +166,78 @@ producers = (
             "/data/customer",
             "/data/request/http_response",
             "/data/request/body/0",
-            ["/timestamp", "timestamp"]
+            ["/timestamp", "timestamp"],
         );
     } );
 .RE
 .PP
+If further filtering of the data should be required, this array can be extended
+with actions and filters. The standard action is to \fIstore\fR, the standard
+filter is \fInoop\fR.
+.PP
+A filter returns boolean true or false. An action takes this return value and
+decides what to do with it. If the action is \fIstore\fR, it'll return true
+no matter what the filter says. Filter \fInoop\fR will also always be true.
+.PP
+The datastructure above is transformed to look like this under the hood:
+.PP
+producers = (
+    {
+        type = "exports"
+        threads = 1;
+        topic = "data";
+        jpointers = (
+            [ "/data/customer", "text", "store", "noop" ],
+            [ "/data/request/http_response", "text", "store", "noop" ],
+            [ "/data/request/body/0", "text", "store", "noop" ],
+            [ "/timestamp", "timestamp"],
+        );
+    } );
+.RE
+.PP
+Exports supports a variety of actions and filters:
+.PP
+.TS
+box, center, tab (@);
+ c | c
+CfCB | CfCB |CfCB.
+action@description@stores data
+=
+store@store field@yes
+store_true@store field if filter is true@yes
+discard_false@discard message if filter is false@no
+discard_true@discard message if filter is true@no
+.TE
+.PP
+Do note that some filters require an additional data field:
+.TS
+box, center, tab (@);
+ c | c | c
+CfCB | CfCB | CfCB.
+filter@description@data
+=
+noop@return true@-
+exists@does the json_pointer point to an existing field@string
+match@compare result of json_pointer against a string@string
+substr@find string in result@string
+.TE
+.PP
+This functionality is useful if you want only a subset of the data,
+for example only non-error messages of customers with Doe in their name:
+.PP
+producers = (
+    {
+        type = "exports"
+        threads = 1;
+        topic = "data";
+        jpointers = (
+            [ "/error", "text", "discard_true", "exists" ],
+            [ "/data/customer", "text", "store_true", "substr", "Doe" ],
+            "/data/request/http_response",
+            "/data/request/body/0",
+            ["/timestamp", "timestamp"],
+        );
+    } );
+.RE
+.PP
+As always, feel free to implement more of what you need.

--- a/src/exports.c
+++ b/src/exports.c
@@ -425,6 +425,10 @@ _needles(config_setting_t *needlestack, Internal internal)
 
         member = config_setting_get_elem(setting, 0);
         current->jpointer = strdup(config_setting_get_string(member));
+        if (!current->jpointer) {
+            logger_log("%s %d: Failed to strdup", __FILE__, __LINE__);
+            abort();
+        }
 
         member = config_setting_get_elem(setting, 1);
         pqtype = _pqtype_enum(config_setting_get_string(member));
@@ -555,12 +559,11 @@ int
 _deref(json_object *haystack, Internal internal)
 {
     json_object *found;
-    int ret = 0;
 
     Needles *needles = internal->needles;
     for (int i = 0; i < internal->ncount; i++) {
         found = NULL;
-        ret = json_pointer_get(haystack, needles[i]->jpointer, &found);
+        int ret = json_pointer_get(haystack, needles[i]->jpointer, &found);
 
         if(!needles[i]->action(
                 needles[i]->filter(ret, found, needles[i]),

--- a/src/exports.c
+++ b/src/exports.c
@@ -773,9 +773,9 @@ exporter_validate(UNUSED config_setting_t *config)
                 goto error;
             }
             jpointer = strdup(conf);
-            pqtype = strdup("text");
-            action = strdup("store");
-            filter = strdup("noop");
+            pqtype = "text";
+            action = "store";
+            filter = "noop";
         } else if (config_setting_is_array(child) == CONFIG_TRUE) {
             member = config_setting_get_elem(child, 0);
             if(member == NULL) {
@@ -793,11 +793,11 @@ exporter_validate(UNUSED config_setting_t *config)
 
             member = config_setting_get_elem(child, 1);
             if(member == NULL)
-                pqtype = strdup("text");
+                pqtype = "text";
             else {
                 conf = config_setting_get_string(member);
                 if(conf == NULL)
-                    pqtype = strdup("text");
+                    pqtype = "text";
                 else if(!_pqtype_enum(conf)) {
                     fprintf(stderr, "%s %d: not a valid type transformation %s\n",
                     __FILE__, __LINE__, conf);
@@ -808,11 +808,11 @@ exporter_validate(UNUSED config_setting_t *config)
 
             member = config_setting_get_elem(child, 2);
             if(member == NULL)
-                action = strdup("store");
+                action = "store";
             else {
                 conf = config_setting_get_string(member);
                 if(conf == NULL)
-                    action = strdup("store");
+                    action = "store";
                 else if(!_actiontype_enum(conf)) {
                     fprintf(stderr, "%s %d: not a valid action type %s\n",
                     __FILE__, __LINE__, conf);
@@ -823,11 +823,11 @@ exporter_validate(UNUSED config_setting_t *config)
 
             member = config_setting_get_elem(child, 3);
             if(member == NULL)
-               filter = strdup("noop");
+               filter = "noop";
             else {
                 conf = config_setting_get_string(member);
                 if(conf == NULL)
-                    filter = strdup("noop");
+                    filter = "noop";
                 else if(!_filtertype_enum(conf)) {
                     fprintf(stderr, "%s %d: not a valid filter type %s\n",
                     __FILE__, __LINE__, conf);
@@ -844,7 +844,7 @@ exporter_validate(UNUSED config_setting_t *config)
                 }
                 conf = config_setting_get_string(member);
                 if(conf == NULL) {
-                    fprintf(stderr, "%s %d: filter needs configuration %s\n",
+                    fprintf(stderr, "%s %d: filter needs configuration %s",
                     __FILE__, __LINE__, conf);
                     goto error;
                 }

--- a/src/exports.c
+++ b/src/exports.c
@@ -555,6 +555,8 @@ _deref(json_object *haystack, Internal internal)
     Needles *needles = internal->needles;
     for (int i = 0; i < internal->ncount; i++) {
         found = NULL;
+        /* json_pointer_get returns negative if an error (or not found)
+         * returns 0 if it succeeds */
         int ret = json_pointer_get(haystack, needles[i]->jpointer, &found);
 
         if(!needles[i]->action(

--- a/src/exports.c
+++ b/src/exports.c
@@ -48,8 +48,7 @@ static bool _filter_exists (int jpointer, json_object *found, Needles current);
 
 static bool _action_store (bool filter_ret, json_object *found, Needles current);
 static bool _action_store_true (bool filter_ret, json_object *found, Needles current);
-static bool _action_discard_false (bool filter_ret, json_object *found, Needles current);
-static bool _action_discard_true (bool filter_ret, json_object *found, Needles current);
+static bool _action_discard_true_false (bool filter_ret, json_object *found, Needles current);
 
 // Types of postgres fields
 typedef enum {  // todo: add jsonb, int.
@@ -88,8 +87,8 @@ static const struct {
         {action_undef, "undef", NULL, false},
         {action_store, "store", &_action_store, true},
         {action_store_true, "store_true", &_action_store_true, true},
-        {action_discard_false, "discard_false", &_action_discard_false, false},
-        {action_discard_true, "discard_true", &_action_discard_true, false}
+        {action_discard_false, "discard_false", &_action_discard_true_false, false},
+        {action_discard_true, "discard_true", &_action_discard_true_false, false}
 };
 
 // Types of filters to be applied on data
@@ -222,17 +221,10 @@ _action_store_true(bool filter_ret, UNUSED json_object *found,
 }
 
 static bool
-_action_discard_false(bool filter_ret, UNUSED json_object *found,
+_action_discard_true_false(bool filter_ret, UNUSED json_object *found,
     UNUSED Needles current)
 {
     return filter_ret;
-}
-
-static bool
-_action_discard_true(bool filter_ret, UNUSED json_object *found,
-    UNUSED Needles current)
-{
-    return !filter_ret;
 }
 
 static bool

--- a/src/exports.c
+++ b/src/exports.c
@@ -837,7 +837,8 @@ exporter_validate(UNUSED config_setting_t *config)
                     data = conf;
             }
         } else if (config_setting_is_group(child) == CONFIG_TRUE) {
-            CONF_L_IS_STRING(child, "jpointer", &jpointer, "failed to parse config");
+            if(!CONF_L_IS_STRING(child, "jpointer", &jpointer, "failed to parse config"))
+                goto error;
 
             if(config_setting_lookup_string(child, "pqtype", &conf) == CONFIG_TRUE) {
                 if (!_pqtype_enum(conf)) {

--- a/src/exports.c
+++ b/src/exports.c
@@ -774,7 +774,7 @@ exporter_validate(UNUSED config_setting_t *config)
         if (config_setting_is_scalar(child) == CONFIG_TRUE) {
             conf = config_setting_get_string(child);
             if(conf == NULL) {
-                fprintf(stderr, "%s %d: couldn't parse config at %ud\n",
+                fprintf(stderr, "%s %d: couldn't parse config at %u\n",
                 __FILE__, __LINE__, config_setting_source_line(child));
                 goto error;
             }
@@ -788,7 +788,7 @@ exporter_validate(UNUSED config_setting_t *config)
             }
             conf = config_setting_get_string(member);
             if(conf == NULL) {
-                fprintf(stderr, "%s %d: couldn't parse config at %ud\n",
+                fprintf(stderr, "%s %d: couldn't parse config at %u\n",
                 __FILE__, __LINE__, config_setting_source_line(child));
                 goto error;
             }
@@ -882,7 +882,7 @@ exporter_validate(UNUSED config_setting_t *config)
                 }
             }
         } else {
-            fprintf(stderr, "%s %d: jpointer needs to be a"
+            fprintf(stderr, "%s %d: jpointer needs to be a "
             "string/array/group\n", __FILE__, __LINE__);
         }
         config_setting_set_string_elem(new, 0, jpointer);

--- a/src/exports.c
+++ b/src/exports.c
@@ -772,7 +772,8 @@ exporter_validate(UNUSED config_setting_t *config)
                 __FILE__, __LINE__, config_setting_source_line(child));
                 goto error;
             }
-            jpointer = strdup(conf);
+            if(!(jpointer = strdup(conf)))
+                goto err_strdup;
             pqtype = "text";
             action = "store";
             filter = "noop";
@@ -789,7 +790,8 @@ exporter_validate(UNUSED config_setting_t *config)
                 __FILE__, __LINE__, config_setting_source_line(child));
                 goto error;
             }
-            jpointer = strdup(conf);
+            if(!(jpointer = strdup(conf)))
+                goto err_strdup;
 
             member = config_setting_get_elem(child, 1);
             if(member == NULL)
@@ -803,7 +805,8 @@ exporter_validate(UNUSED config_setting_t *config)
                     __FILE__, __LINE__, conf);
                     goto error;
                 } else
-                    pqtype = strdup(conf);
+                    if(!(pqtype = strdup(conf)))
+                        goto err_strdup;
             }
 
             member = config_setting_get_elem(child, 2);
@@ -818,7 +821,8 @@ exporter_validate(UNUSED config_setting_t *config)
                     __FILE__, __LINE__, conf);
                     goto error;
                 } else
-                    action = strdup(conf);
+                    if(!(action = strdup(conf)))
+                        goto err_strdup;
             }
 
             member = config_setting_get_elem(child, 3);
@@ -833,7 +837,8 @@ exporter_validate(UNUSED config_setting_t *config)
                     __FILE__, __LINE__, conf);
                     goto error;
                 } else
-                    filter = strdup(conf);
+                    if(!(filter = strdup(conf)))
+                        goto err_strdup;
             }
             if(filter_types[_filtertype_enum(conf)].needs_data) {
                 member = config_setting_get_elem(child,4);
@@ -848,7 +853,8 @@ exporter_validate(UNUSED config_setting_t *config)
                     __FILE__, __LINE__, conf);
                     goto error;
                 }
-                data = strdup(conf);
+                if(!(data = strdup(conf)))
+                    goto err_strdup;
             }
         } else {
             fprintf(stderr, "%s %d: jpointer needs to be a string/array\n",
@@ -868,6 +874,9 @@ exporter_validate(UNUSED config_setting_t *config)
     }
 
     return true;
+    err_strdup:
+    fprintf(stderr, "%s %d: failed to strdup\n",
+        __FILE__, __LINE__);
     error:
     return false;
 }

--- a/src/exports.c
+++ b/src/exports.c
@@ -99,7 +99,7 @@ typedef enum {
     filter_match,       // match string
     filter_substr,      // match substring
     filter_exists,      // json key exists
-    filter_pcrematch,   // pcre match
+// TODO:    filter_pcrematch,   // pcre match
 } FilterTypes;
 
 static const struct {
@@ -113,7 +113,7 @@ static const struct {
         {filter_match, "match", &_filter_match, true},
         {filter_substr, "substr", &_filter_substr, true},
         {filter_exists, "exists", &_filter_exists, false},
-        {filter_pcrematch, "pcrematch", NULL, true},
+// TODO:        {filter_pcrematch, "pcrematch", NULL, true},
 };
 
 static char *

--- a/src/exports.c
+++ b/src/exports.c
@@ -239,7 +239,7 @@ static bool
 _filter_match(int jpointer, json_object *found,
     UNUSED Needles current)
 {
-    if(jpointer != 0) // no data to match against
+    if(jpointer != 0 || !found) // no data to match against
         return false;
     if(strcmp(json_object_get_string(found), current->filter_data) == 0)
         return true;
@@ -250,7 +250,7 @@ static bool
 _filter_substr(int jpointer, json_object *found,
     UNUSED Needles current)
 {
-    if(jpointer != 0) // no data to match against
+    if(jpointer != 0 || !found) // no data to match against
         return false;
     if(strstr(json_object_get_string(found), current->filter_data))
         return true;
@@ -559,6 +559,7 @@ _deref(json_object *haystack, Internal internal)
 
     Needles *needles = internal->needles;
     for (int i = 0; i < internal->ncount; i++) {
+        found = NULL;
         ret = json_pointer_get(haystack, needles[i]->jpointer, &found);
 
         if (!

--- a/src/exports.c
+++ b/src/exports.c
@@ -218,27 +218,21 @@ static bool
 _action_store_true(bool filter_ret, UNUSED json_object *found,
     UNUSED Needles current)
 {
-    if(filter_ret)
-        return true;
-    return false;
+    return filter_ret;
 }
 
 static bool
 _action_discard_false(bool filter_ret, UNUSED json_object *found,
     UNUSED Needles current)
 {
-    if(filter_ret)
-        return true;
-    return false;
+    return filter_ret;
 }
 
 static bool
 _action_discard_true(bool filter_ret, UNUSED json_object *found,
     UNUSED Needles current)
 {
-    if(filter_ret)
-        return false;
-    return true;
+    return !filter_ret;
 }
 
 static bool

--- a/src/exports.c
+++ b/src/exports.c
@@ -768,7 +768,7 @@ exporter_validate(UNUSED config_setting_t *config)
         if (config_setting_is_scalar(child) == CONFIG_TRUE) {
             conf = config_setting_get_string(child);
             if(conf == NULL) {
-                fprintf(stderr, "%s %d: couldn't parse config at %ud",
+                fprintf(stderr, "%s %d: couldn't parse config at %ud\n",
                 __FILE__, __LINE__, config_setting_source_line(child));
                 goto error;
             }
@@ -785,7 +785,7 @@ exporter_validate(UNUSED config_setting_t *config)
             }
             conf = config_setting_get_string(member);
             if(conf == NULL) {
-                fprintf(stderr, "%s %d: couldn't parse config at %ud",
+                fprintf(stderr, "%s %d: couldn't parse config at %ud\n",
                 __FILE__, __LINE__, config_setting_source_line(child));
                 goto error;
             }
@@ -799,7 +799,7 @@ exporter_validate(UNUSED config_setting_t *config)
                 if(conf == NULL)
                     pqtype = strdup("text");
                 else if(!_pqtype_enum(conf)) {
-                    fprintf(stderr, "%s %d: not a valid type transformation %s",
+                    fprintf(stderr, "%s %d: not a valid type transformation %s\n",
                     __FILE__, __LINE__, conf);
                     goto error;
                 } else
@@ -814,7 +814,7 @@ exporter_validate(UNUSED config_setting_t *config)
                 if(conf == NULL)
                     action = strdup("store");
                 else if(!_actiontype_enum(conf)) {
-                    fprintf(stderr, "%s %d: not a valid action type %s",
+                    fprintf(stderr, "%s %d: not a valid action type %s\n",
                     __FILE__, __LINE__, conf);
                     goto error;
                 } else
@@ -829,7 +829,7 @@ exporter_validate(UNUSED config_setting_t *config)
                 if(conf == NULL)
                     filter = strdup("noop");
                 else if(!_filtertype_enum(conf)) {
-                    fprintf(stderr, "%s %d: not a valid filter type %s",
+                    fprintf(stderr, "%s %d: not a valid filter type %s\n",
                     __FILE__, __LINE__, conf);
                     goto error;
                 } else
@@ -838,13 +838,13 @@ exporter_validate(UNUSED config_setting_t *config)
             if(filter_types[_filtertype_enum(conf)].needs_data) {
                 member = config_setting_get_elem(child,4);
                 if(member == NULL) {
-                    fprintf(stderr, "%s %d: filter needs configuration %s",
+                    fprintf(stderr, "%s %d: filter needs configuration %s\n",
                     __FILE__, __LINE__, conf);
                     goto error;
                 }
                 conf = config_setting_get_string(member);
                 if(conf == NULL) {
-                    fprintf(stderr, "%s %d: filter needs configuration %s",
+                    fprintf(stderr, "%s %d: filter needs configuration %s\n",
                     __FILE__, __LINE__, conf);
                     goto error;
                 }

--- a/src/exports.c
+++ b/src/exports.c
@@ -48,7 +48,8 @@ static bool _filter_exists (int jpointer, json_object *found, Needles current);
 
 static bool _action_store (bool filter_ret, json_object *found, Needles current);
 static bool _action_store_true (bool filter_ret, json_object *found, Needles current);
-static bool _action_discard_true_false (bool filter_ret, json_object *found, Needles current);
+static bool _action_discard_false (bool filter_ret, json_object *found, Needles current);
+static bool _action_discard_true (bool filter_ret, json_object *found, Needles current);
 
 // Types of postgres fields
 typedef enum {  // todo: add jsonb, int.
@@ -87,8 +88,8 @@ static const struct {
         {action_undef, "undef", NULL, false},
         {action_store, "store", &_action_store, true},
         {action_store_true, "store_true", &_action_store_true, true},
-        {action_discard_false, "discard_false", &_action_discard_true_false, false},
-        {action_discard_true, "discard_true", &_action_discard_true_false, false}
+        {action_discard_false, "discard_false", &_action_discard_false, false},
+        {action_discard_true, "discard_true", &_action_discard_true, false}
 };
 
 // Types of filters to be applied on data
@@ -221,10 +222,17 @@ _action_store_true(bool filter_ret, UNUSED json_object *found,
 }
 
 static bool
-_action_discard_true_false(bool filter_ret, UNUSED json_object *found,
+_action_discard_false(bool filter_ret, UNUSED json_object *found,
     UNUSED Needles current)
 {
     return filter_ret;
+}
+
+static bool
+_action_discard_true(bool filter_ret, UNUSED json_object *found,
+    UNUSED Needles current)
+{
+    return !filter_ret;
 }
 
 static bool


### PR DESCRIPTION
To move https://github.com/adjust/data-science/issues/816 along, I've implemented filtering on json data. Data can be now stored or discarded if certain conditions are met.
The semantics of functionality are described in schaufel.conf.5.

In the long run, this PR lays the framework to deprecate gin indexes in bagger.
