### PR TITLE
rdkafka offset commit api

### DIFF
--- a/man/schaufel.1
+++ b/man/schaufel.1
@@ -90,8 +90,10 @@ outputs every message that it reads to stdout.
 As a consumer, schaufel reads line-wise (preserving the newline). As a
 producer it writes the messages as they are.
 .SS kafka
-As a consumer, schaufel joins a consumer group. As a producer it'll
-simply write to a topic.
+As a consumer, schaufel joins a consumer group. If the consumer group does
+not exist yet, it'll assume the latest available offsets as a starting point.
+To change this behaviour you'll require a schaufel.conf file.
+As a producer it'll simply write to a topic.
 .SS redis
 As a consumer, schaufel will LPUSH from a list. As a producer it'll BLPOP.
 .SS postgres

--- a/man/schaufel.conf.5
+++ b/man/schaufel.conf.5
@@ -144,6 +144,10 @@ consumers = (
         group = "schaufel_queue_1";
         kafka_options = {
             partition_assignment_strategy = "roundrobin";
+            enable_auto_commit = "false;
+        };
+        topic_options = {
+            auto_offset_reset = "beginning";
         };
     });
 .PP

--- a/src/kafka.c
+++ b/src/kafka.c
@@ -115,17 +115,20 @@ static void kafka_producer_defaults(config_setting_t *c)
 
 static void kafka_consumer_defaults(config_setting_t *c)
 {
-    config_setting_t *topic_options;
+    config_setting_t *kafka_options;
 
-    config_set_default_string(c, "kafka_options/offset_store_method", "broker");
-
-    topic_options = config_create_path(c, "topic_options", CONFIG_TYPE_GROUP);
-    if (topic_options)
+    kafka_options = config_create_path(c, "kafka_options", CONFIG_TYPE_GROUP);
+    if (kafka_options)
     {
-        config_set_default_string(topic_options, "enable_auto_commit", "true");
-        config_set_default_string(topic_options, "auto_commit_interval_ms", "10");
-        config_set_default_string(topic_options, "auto_offset_reset", "latest");
+        /* enable.auto.commit and enable.auto.offset.store
+         * are default values, they're only here to be explicit */
+        config_set_default_string(kafka_options, "enable_auto_commit", "true");
+        config_set_default_string(kafka_options, "enable_auto_offset_store", "true");
+        config_set_default_string(kafka_options, "auto_commit_interval_ms", "10");
     }
+
+    // naively assume you don't want to touch past data
+    config_set_default_string(c, "topic_options/auto_offset_reset", "latest");
 }
 
 typedef struct Meta {

--- a/src/kafka.c
+++ b/src/kafka.c
@@ -219,7 +219,6 @@ kafka_consumer_meta_init(const char *broker,
     rd_kafka_conf_set_default_topic_conf(conf, topic_conf);
 
     rd_kafka_conf_set_rebalance_cb(conf, rebalance_cb);
-    rd_kafka_conf_set_dr_msg_cb(conf, dr_msg_cb);
 
     rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
     if (!rk)

--- a/t/config_test.c
+++ b/t/config_test.c
@@ -19,16 +19,6 @@ bool lookup_str(config_t* config, const char *string, const char *test)
     return true;
 }
 
-bool lookup_int(config_t* config, const char *string, int test)
-{
-    int retval = 0;
-    if(config_lookup_int(config, string, &retval) != CONFIG_TRUE)
-        return false;
-    if(retval != test)
-        return false;
-    return true;
-}
-
 void _t_group_apply(const char *key, const char *value, void *arg)
 {
     const char *elem = NULL;

--- a/t/config_test.c
+++ b/t/config_test.c
@@ -1,0 +1,92 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <setjmp.h>
+
+#include "test/test.h"
+#include "utils/config.h"
+#include "utils/options.h"
+
+static jmp_buf buf;
+
+bool lookup_str(config_t* config, const char *string, const char *test)
+{
+    const char *retval = NULL;
+    if(config_lookup_string(config, string, &retval) != CONFIG_TRUE)
+        return false;
+    if(strcmp(test,retval))
+        return false;
+    return true;
+}
+
+bool lookup_int(config_t* config, const char *string, int test)
+{
+    int retval = 0;
+    if(config_lookup_int(config, string, &retval) != CONFIG_TRUE)
+        return false;
+    if(retval != test)
+        return false;
+    return true;
+}
+
+void _t_group_apply(const char *key, const char *value, void *arg)
+{
+    const char *elem = NULL;
+    config_setting_t *kopt = (config_setting_t *) arg;
+    config_setting_lookup_string(kopt,key,&elem);
+
+    if(elem == NULL)
+        longjmp(buf,1);
+    if(strcmp(value,elem))
+        longjmp(buf,1);
+
+    return;
+}
+
+int
+main(void)
+{
+    config_t config;
+    config_setting_t *kafka_options, *consumer;
+
+    Options o;
+
+    config_init(&config);
+    memset(&o, 0, sizeof(o));
+
+    config_read_string(&config,
+        "logger={};"
+        "producers=();"
+        "consumers=({});"
+    );
+    consumer = config_lookup(&config, "consumers.[0]");
+
+    // test config_set_default_string, config_create_path
+    kafka_options = config_create_path(consumer, "kafka_options", CONFIG_TYPE_GROUP);
+    config_set_default_string(kafka_options, "enable_auto_commit", "true");
+    config_set_default_string(kafka_options, "enable_auto_offset_store", "true");
+    config_set_default_string(kafka_options, "auto_commit_interval_ms", "10");
+    config_set_default_string(consumer, "topic_options/auto_offset_reset", "latest");
+
+
+    if(!lookup_str(&config, "consumers.[0].kafka_options.enable_auto_commit", "true"))
+        goto error;
+    if(!lookup_str(&config, "consumers.[0].kafka_options.enable_auto_offset_store", "true"))
+    if(!lookup_str(&config, "consumers.[0].kafka_options.auto_commit_interval_ms", "10"))
+        goto error;
+    if(!lookup_str(&config, "consumers.[0].topic_options.auto_offset_reset", "latest"))
+        goto error;
+
+    // test config_group_apply, set a longjump so we can error out and cleanup
+    if(!setjmp(buf))
+        config_group_apply(kafka_options,_t_group_apply,kafka_options);
+    else
+        goto error;
+
+    config_destroy(&config);
+    return 0;
+
+    error:
+    config_destroy(&config);
+    return 1;
+}


### PR DESCRIPTION
Librdkafka has warned about the per topic commit api being deprecated for a while, and with api v2 it is going dropped.
Luckily the change required to switch to the global commit api is miniscule. I've taken the liberty of adding test cases for the involved src/config/config.c functions.
Furthermore, I've removed the useless producer callback from kafka_consumer_meta_init. rdkafka now initialises without warnings.
fix: #61