### PR TITLE
Logger rework

### DIFF
--- a/doc/dummy.conf
+++ b/doc/dummy.conf
@@ -1,10 +1,5 @@
 # Simplest possible configuration for testing
 
-logger :
-{
-  file = "/tmp/example.log";
-  type = "file";
-};
 consumers = (
     {
         type = "dummy";

--- a/man/schaufel.1
+++ b/man/schaufel.1
@@ -82,8 +82,16 @@ Redis consumer/producer pipelining. Batch n commands before inspecting
 the result. Upstream recommends no more than 10000 commands be batched.
 This feature is purely optional.
 .TP
-.B \-l \fIfilename
-Set the logger output filename
+.B \-l \fIlogstring\fR
+Configure logger. Possible values are
+\fBFILE:mode:filename\fR | \fBFILE:filename\fR | \fBfilename\fR |
+\fBSTDOUT\fR | \fBSTDERR\fR | \fBNULL\fB | \fBSYSLOG:ident:facility\fR |
+\fB SYSLOG:facility \fR | \fBSYSLOG\fR
+Any string that is not parsed is treated as a filename. This is to maintain
+backwards compatibility. The standard mode of files created by the logger
+is \fB0640\fR.
+If no logger is specified, schaufel with log to stderr.
+
 .TP
 .B \-V
 Print schaufel version

--- a/man/schaufel.conf.5
+++ b/man/schaufel.conf.5
@@ -16,17 +16,36 @@ Schaufel expects three sections: \fBlogger\fR, \fBconsumers\fR and
 .SS logger
 The logger section defines the workings of schaufels logging.
 .PP
-It expects you to set a \fItype\fR, which at the moment only supports
-logging to \fIfile\fR.
+It expects you to set a \fItype\fR. Types supported are
+\fBsyslog\fR|\fBstderr\fR|\fBstdout\fR|\fBnull\fR|\fBfile\fR.
+.PP
+\fBfile\fR as a type supports \fBmode\fR as octal and requires \fBfile\fR
+as a path. The standard mode is 0640.
+
 .RS
 .PP
  logger =
  {
     file = "/var/log/schaufel/schaufel.log";
     type = "file";
+    mode = 0644;
  };
 .RE
 .PP
+\fBsyslog\fR as a type supports \fBident\fR and \fBfacility\fR and strings.
+\fBident\fR is the string your schaufel instance identifies as.
+\fBfacility\fR is the logging facility, the default is facility \fIdaemon\fR.
+.RS
+.PP
+ logger =
+ {
+    type = "syslog";
+    ident = "schaufel_test";
+    facility = "user";
+ };
+.RE
+.PP
+
 .SS consumers
 Consumers are of the libconfig list type as there may be multiple
 consumers defined. The necessary minimum configuration is a \fItype\fR

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -11,6 +11,7 @@
 
 typedef void (*group_func)(const char *key, const char *value, void *arg);
 
+void logger_parse(char *, config_setting_t *);
 
 void read_config(config_t *config, char *cfile);
 

--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -6,40 +6,156 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <regex.h>
 
 #include "utils/config.h"
 #include "utils/helper.h"
 #include "utils/logger.h"
+#include "utils/strlwr.h"
 
+#define SYSLOG_NAMES 1
+#include <syslog.h>
 
-static int log_fd;
-static char *log_fname;
 static volatile atomic_bool logger_state = false;
 static _Thread_local char log_buffer[LOG_BUFFER_SIZE + 2];
+
+static struct {
+    void (*log)(char *, size_t);
+    void (*free)(void);
+    int loglevel;
+    int fd;
+    int facility;
+    bool timestamp;
+} logger;
+
+static void log_fd(char *, size_t);
+static void log_null(char *, size_t);
+static void log_syslog(char *, size_t);
+static void log_syslog_free(void);
 
 bool logger_validate(config_setting_t *config)
 {
     const char *retval = NULL;
+    char *type = NULL;
 
-    // this check is a mere placeholder
     if(!CONF_L_IS_STRING(config, "type", &retval,
-        "logger: need a type (file only atm)"))
+        "logger: need a type (file/stdout/stderr/syslog/null)"))
         goto error;
-    if(strlen(retval) < 4 || strncmp(retval, "file", strlen("file"))) {
-        fprintf(stderr, "logger: need a type (file only atm)\n");
+
+    // convert to lowercase
+    type = strdup(retval);
+    if(type == NULL)
+    {
+        fprintf(stderr, "%s %d: failed allocate!\n",
+            __FILE__, __LINE__);
+        goto error;
+    }
+    type = strlwr(type);
+
+    size_t len = strnlen(type,20);
+    if (len == 4 && strncmp(type,"file",4) == 0)
+    {
+        // set standard mode
+        mode_t m = 0640;
+        config_setting_lookup_int(config, "mode", (int *) &m);
+        if (m & (S_ISVTX | S_ISGID | S_ISUID))
+        {
+            fprintf(stderr,
+                "%s %d: Cowardly refusing to create file mode %04o\n",
+                __FILE__, __LINE__, m);
+            goto error;
+        }
+        if (m > 07777)
+        {
+            fprintf(stderr,
+                "%s %d: Illegal mode: %o\n",
+                __FILE__, __LINE__, m);
+            goto error;
+        }
+
+        if(config_setting_lookup_string(config, "file", &retval)
+            != CONFIG_TRUE)
+        {
+            fprintf(stderr, "%s, %d: missing configuration for type: "
+                "%s\n", __FILE__, __LINE__, retval);
+            goto error;
+        }
+    }
+    else if (len == 6 && strncmp(type,"stdout",6) == 0)
+        (void) true;
+    else if (len == 6 && strncmp(type,"stderr",6) == 0)
+        (void) true;
+    else if (len == 4 && strncmp(type,"null",4) == 0)
+        (void) true;
+    else if (len == 6 && strncmp(type,"syslog",6) == 0)
+    {
+        const char *facility = NULL, *ident = "schaufel";
+        config_setting_t *setting = config_setting_get_member(
+            config, "facility");
+
+        if (setting == NULL)
+        {
+            // set default facility to daemon
+            setting = config_setting_add(config, "facility",
+                CONFIG_TYPE_STRING);
+            config_setting_set_string(setting, "daemon");
+        }
+        else if (config_setting_lookup_string(
+            config, "facility", &facility) == CONFIG_TRUE)
+        {
+            facility = config_setting_get_string(setting);
+            // TODO:
+            // facilitynames needs _BSD_SOURCE//_GNU_SOURCE
+            int i = 0, res;
+
+            do {
+                res = facilitynames[i].c_val;
+                if (strcmp(facilitynames[i].c_name,facility) == 0)
+                    break;
+            } while(facilitynames[++i].c_val > -1);
+
+            if (res == -1)
+            {
+                fprintf(stderr, "%s %d: unknown syslog facility %s\n",
+                    __FILE__, __LINE__, facility);
+                goto error;
+            }
+        }
+        else
+        {
+            fprintf(stderr, "%s %d: expected logger facility to be"
+                " of type string\n", __FILE__, __LINE__);
+            goto error;
+        }
+
+        setting = config_setting_get_member(config, "ident");
+        if (setting == NULL)
+        {
+            setting = config_setting_add(config, "ident", CONFIG_TYPE_STRING);
+            config_setting_set_string(setting, ident);
+        }
+        else if (config_setting_lookup_string(config, "ident", &ident)
+            != CONFIG_TRUE)
+        {
+            fprintf(stderr, "%s %d: syslog ident must be a string \n",
+                __FILE__, __LINE__);
+            // todo: limits on syslogs ident?
+            goto error;
+        }
+    }
+    else
+    {
+        fprintf(stderr, "%s %d: unsupported type %s\n",
+            __FILE__, __LINE__, type);
         goto error;
     }
 
-    retval = NULL;
-    if(config_setting_lookup_string(config, "file", &retval)
-        != CONFIG_TRUE) {
-        fprintf(stderr, "logger: missing configuration for type: %s\n", "file");
-        goto error;
-    }
+    free(type);
 
     return true;
 
     error:
+    free(type);
     return false;
 }
 
@@ -50,21 +166,87 @@ bool get_logger_state()
 
 void logger_init(config_setting_t *config)
 {
-    const char *fname;
-    config_setting_lookup_string(config,"file",&fname);
+    const char *fname = NULL, *type;
+    mode_t mode = 0640;
+
+    // all loggers except syslog need a timestamp
+    memset((void *) &logger, 0, sizeof(logger));
+    logger.timestamp = true;
+
+    config_setting_lookup_string(config,"type",&type);
+    if (strncmp(type, "file", 4) == 0)
+    {
+        config_setting_lookup_string(config,"file",&fname);
+        config_setting_lookup_int(config,"mode",(int *) &mode);
+        logger.fd = open(fname, O_CREAT | O_APPEND | O_WRONLY, mode);
+
+        if (logger.fd < 0)
+        {
+            fprintf(stderr, "could not open logger fh: %s", strerror(errno));
+            exit(1);
+        }
+        logger.log = &log_fd;
+    }
+    else if (strncmp(type, "stderr", 6) == 0)
+    {
+        logger.fd = fileno(stderr);
+        logger.log = &log_fd;
+    }
+    else if (strncmp(type, "stdout", 6) == 0)
+    {
+        logger.fd = fileno(stdout);
+        logger.log = &log_fd;
+    }
+    else if (strncmp(type, "null", 6) == 0)
+    {
+        logger.log = &log_null;
+    }
+    else if (strncmp(type, "syslog", 6) == 0)
+    {
+        // todo, facility
+        const char *facility = NULL, *ident = NULL;
+
+        // validator guarantees these exist
+        config_setting_lookup_string(config, "facility", &facility);
+        config_setting_lookup_string(config, "ident", &ident);
+
+
+        if (facility == NULL || ident == NULL)
+        {
+            fprintf(stderr, "%s %d: expected facility and ident\n",
+                __FILE__, __LINE__);
+            exit(1);
+        }
+
+        int i = 0, res;
+
+        do {
+            res = facilitynames[i].c_val;
+
+            if (strcmp(facilitynames[i].c_name,facility) == 0)
+                break;
+        } while (facilitynames[i++].c_val > -1);
+
+        if (res == -1)
+        {   // paranoia error handling
+            fprintf(stderr, "%s %d: facility \"%s\" does not exist",
+                __FILE__, __LINE__, facility);
+            exit(1);
+        }
+
+        // use LOG_CONS to log to console if syslog is unavailable
+        openlog(ident, LOG_PID | LOG_CONS, res);
+        logger.log = &log_syslog;
+        logger.free = &log_syslog_free;
+        logger.timestamp = false;
+    }
+    else
+    {
+        fprintf(stderr, "no such logger type: %s", type);
+        exit(1);
+    }
     log_buffer[0] = '\0';
-    log_fname     = strdup(fname);
-    if (!log_fname)
-    {
-        fprintf(stderr, "failed to allocate memory: %s\n", strerror(errno));
-        exit(1);
-    }
-    log_fd        = open(fname, O_CREAT | O_APPEND | O_WRONLY, 0640);
-    if (log_fd < 0)
-    {
-        fprintf(stderr, "could not open logger fh: %s", strerror(errno));
-        exit(1);
-    }
+
     set_state(&logger_state, true);
 
     logger_log("logger initialized");
@@ -72,12 +254,13 @@ void logger_init(config_setting_t *config)
 
 void logger_free()
 {
-    if (log_fd < 0)
+    if (logger.fd < 0)
         return;
-    free(log_fname);
-    close(log_fd);
+    if(logger.free)
+        logger.free();
+    close(logger.fd);
     log_buffer[0] = '\0';
-    log_fd = -1;
+    logger.fd = -1;
 }
 
 static size_t buffer_set_timestamp(char *buf)
@@ -85,19 +268,43 @@ static size_t buffer_set_timestamp(char *buf)
     size_t len;
     struct tm *local;
     time_t tm = time(NULL);
+
+    if (logger.timestamp == false)
+    {
+        buf[0] = '\0';
+        return 0;
+    }
+
     local = localtime(&tm);
     len = strftime(buf, LOG_BUFFER_SIZE, "%a %b %e %T %Y ", local);
     if (len == 0)
         buf[0] = '\0';
+
     return len;
 }
 
-static void logger_write(int fd, char *buf, size_t len)
+static void log_fd(char *buf, size_t len)
 {
     if (len > LOG_BUFFER_SIZE + 2)
         len = LOG_BUFFER_SIZE + 2;
-    if (write(fd, buf, (len-1)) < 0)
+
+    if (write(logger.fd, buf, (len-1)) < 0)
         fprintf(stderr, "while writing to logfile %s", strerror(errno));
+}
+
+static void log_syslog(char *buf, UNUSED size_t len)
+{
+    syslog(LOG_INFO | LOG_USER, buf);
+}
+
+static void log_syslog_free(void)
+{
+    closelog();
+}
+
+static void log_null(UNUSED char *buf, UNUSED size_t len)
+{
+    return;
 }
 
 void logger_log(const char *fmt, ...)
@@ -111,5 +318,5 @@ void logger_log(const char *fmt, ...)
         len = LOG_BUFFER_SIZE;
     log_buffer[len++] = '\n';
     log_buffer[len++] = '\0';
-    logger_write(log_fd, log_buffer, len);
+    logger.log(log_buffer, len);
 }

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -15,4 +15,12 @@ void logger_init(config_setting_t *config);
 void logger_free();
 void logger_log(const char *fmt, ...) FORMAT_PRINTF(1,2);
 
+enum loglevel {
+    FATAL,
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG,
+};
+
 #endif

--- a/src/utils/strlwr.c
+++ b/src/utils/strlwr.c
@@ -3,6 +3,7 @@
 // win32 check
 #ifndef strlwr
 #include <ctype.h>
+#include <stddef.h>
 /* strlwr converts upper case string to lower case
  * returns pointer to start of string
  *
@@ -16,5 +17,6 @@ strlwr(char *s1)
     for (; *s1; s1++) *s1 = tolower(*s1);
     return ret;
 }
+
 #endif
 #endif

--- a/src/utils/strlwr.c
+++ b/src/utils/strlwr.c
@@ -1,0 +1,20 @@
+#ifndef _SCHAUFEL_UTILS_STRLWR_H
+#define _SCHAUFEL_UTILS_STRLWR_H
+// win32 check
+#ifndef strlwr
+#include <ctype.h>
+/* strlwr converts upper case string to lower case
+ * returns pointer to start of string
+ *
+ * !do not pass const char!
+ */
+char *
+strlwr(char *s1)
+{
+    char *ret = s1;
+
+    for (; *s1; s1++) *s1 = tolower(*s1);
+    return ret;
+}
+#endif
+#endif

--- a/src/utils/strlwr.h
+++ b/src/utils/strlwr.h
@@ -1,0 +1,4 @@
+#ifndef _SCHAUFEL_UTILS_STRLWR_H
+#define _SCHAUFEL_UTILS_STRLWR_H
+char *strlwr(char *);
+#endif

--- a/t/file_consumer_test.c
+++ b/t/file_consumer_test.c
@@ -18,6 +18,8 @@ main(void)
 
     //logger
     logger = config_setting_add(croot,"logger",CONFIG_TYPE_GROUP);
+    setting = config_setting_add(logger, "type", CONFIG_TYPE_STRING);
+    config_setting_set_string(setting, "file");
     setting = config_setting_add(logger, "file", CONFIG_TYPE_STRING);
     config_setting_set_string(setting, "sample/dummy_log");
     //file

--- a/t/logger_test.c
+++ b/t/logger_test.c
@@ -1,0 +1,95 @@
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "test/test.h"
+#include "utils/config.h"
+#include "utils/logger.h"
+
+config_setting_t *_config_init(config_t *root)
+{
+    if(!root)
+        config_init(root);
+    else {
+        config_destroy(root);
+        config_init(root);
+    }
+    config_read_string(root, "logger: {};");
+    return config_lookup(root, "logger");
+}
+
+int main()
+{
+    config_t root = {0};
+    config_setting_t *logger = NULL;;
+
+    // test full file definition
+    logger = _config_init(&root);
+    logger_parse("FILE:0644:/tmp/schaufel_logtest",logger);
+    pretty_assert(logger_validate(logger) == true);
+    logger = config_lookup(&root,"logger");
+    logger_init(logger);
+    logger_log("testmessage file 1");
+    // We can't actually compare mode because
+    // umask might influence result
+    unlink("/tmp/schaufel_logtest");
+
+    logger_free();
+
+    // test file
+    logger = _config_init(&root);
+    logger_parse("/tmp/schaufel_logtest2",logger);
+    pretty_assert(logger_validate(logger) == true);
+    logger = config_lookup(&root,"logger");
+    logger_init(logger);
+    logger_log("testmessage file 2");
+    unlink("/tmp/schaufel_logtest2");
+    logger_free();
+
+    // stderr (not a test)
+    logger = _config_init(&root);
+    logger_parse("STDERR",logger);
+    pretty_assert(logger_validate(logger) == true);
+    logger = config_lookup(&root,"logger");
+    logger_init(logger);
+    logger_log("testmessage stderr");
+    logger_free();
+
+    // stdout (not a test)
+    logger = _config_init(&root);
+    logger_parse("STDOUT",logger);
+    pretty_assert(logger_validate(logger) == true);
+    logger = config_lookup(&root,"logger");
+    logger_init(logger);
+    logger_log("testmessage stdout");
+    logger_free();
+
+    // null (not a test)
+    logger = _config_init(&root);
+    logger_parse("NULL",logger);
+    pretty_assert(logger_validate(logger) == true);
+    logger = config_lookup(&root,"logger");
+    logger_init(logger);
+    logger_log("testmessage null");
+    logger_free();
+
+    // syslog
+    logger = _config_init(&root);
+    logger_parse("SYSLOG",logger);
+    pretty_assert(logger_validate(logger) == true);
+    logger = config_lookup(&root,"logger");
+    logger_init(logger);
+    logger_log("testmessage syslog 1");
+    logger_free();
+
+    // syslog
+    logger = _config_init(&root);
+    logger_parse("SYSLOG:schaufel_test:daemon",logger);
+    pretty_assert(logger_validate(logger) == true);
+    logger = config_lookup(&root,"logger");
+    logger_init(logger);
+    logger_log("testmessage syslog 2 ");
+    logger_free();
+
+    config_destroy(&root);
+    return 0;
+}

--- a/t/logparse_test.c
+++ b/t/logparse_test.c
@@ -1,0 +1,77 @@
+#include "test/test.h"
+#include "utils/config.h"
+
+config_setting_t *_config_init(config_t *root)
+{
+    if(!root)
+        config_init(root);
+    else {
+        config_destroy(root);
+        config_init(root);
+    }
+    config_read_string(root, "logger: {};");
+    return config_lookup(root, "logger");
+}
+
+int main()
+{
+    config_t root = {0};
+    const char *type, *file, *facility, *ident;
+    config_setting_t *logger = NULL;;
+    int mode;
+
+    // test full file definition
+    logger = _config_init(&root);
+    logger_parse("FILE:0644:foobar",logger);
+    config_lookup_string(&root, "logger/type", &type);
+    config_lookup_string(&root, "logger/file", &file);
+    config_lookup_int(&root, "logger/mode", &mode);
+    pretty_assert(strncmp(type,"file",4) == 0);
+    pretty_assert(strncmp(file,"foobar",6) == 0);
+    pretty_assert(mode == 0644);
+
+    logger = _config_init(&root);
+    logger_parse("FILE:habicht",logger);
+    config_lookup_string(&root, "logger/type", &type);
+    config_lookup_string(&root, "logger/file", &file);
+    config_lookup_int(&root, "logger/mode", &mode);
+    pretty_assert(strncmp(type,"file",4) == 0);
+    pretty_assert(strncmp(file,"habicht",7) == 0);
+
+    logger = _config_init(&root);
+    logger_parse("FILE",logger);
+    config_lookup_string(&root, "logger/type", &type);
+    config_lookup_string(&root, "logger/file", &file);
+    config_lookup_int(&root, "logger/mode", &mode);
+    pretty_assert(strncmp(type,"file",4) == 0);
+    pretty_assert(strncmp(file,"FILE",4) == 0);
+
+    logger = _config_init(&root);
+    logger_parse("SYSLOG",logger);
+    config_lookup_string(&root, "logger/type", &type);
+    pretty_assert(strncmp(type,"syslog",6) == 0);
+
+    logger = _config_init(&root);
+    logger_parse("SYSLOG:schaufel_ident:user",logger);
+    config_lookup_string(&root, "logger/type", &type);
+    pretty_assert(strncmp(type,"syslog",6) == 0);
+    config_lookup_string(&root, "logger/facility", &facility);
+    pretty_assert(strncmp(facility,"user",6) == 0);
+    config_lookup_string(&root, "logger/ident", &ident);
+    pretty_assert(strncmp(ident,"schaufel_ident", 12) == 0);
+
+    logger = _config_init(&root);
+    logger_parse("SYSLOG:daemon",logger);
+    config_lookup_string(&root, "logger/type", &type);
+    pretty_assert(strncmp(type,"syslog",6) == 0);
+    config_lookup_string(&root, "logger/facility", &facility);
+    pretty_assert(strncmp(facility,"daemon",6) == 0);
+
+    logger = _config_init(&root);
+    logger_parse("NULL",logger);
+    config_lookup_string(&root, "logger/type", &type);
+    pretty_assert(strncmp(type,"null",6) == 0);
+
+    config_destroy(&root);
+    return 0;
+}

--- a/t/strlwr_test.c
+++ b/t/strlwr_test.c
@@ -1,0 +1,15 @@
+#include "test/test.h"
+#include "utils/strlwr.h"
+#include <stdlib.h>
+
+int main()
+{
+    char hurz[13] = "Der Habicht!\0";
+    strlwr(hurz);
+    pretty_assert(strcmp(hurz, "der habicht!") == 0);
+
+    char *foo = strlwr(strdup("BAR"));
+    pretty_assert(strcmp(foo, "bar") == 0);
+    free(foo);
+    return 0;
+}


### PR DESCRIPTION
The logger not supporting file modes, not having a sane default, not supporting syslog, etc.pp. have all been troublesome.

This PR extends the logger with some basic functionality. More importantly, it makes the logger default to stderr.