### PR TITLE
utils/logger.c: use gnu definition of syslog (with format)

### DIFF
--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -294,7 +294,7 @@ static void log_fd(char *buf, size_t len)
 
 static void log_syslog(char *buf, UNUSED size_t len)
 {
-    syslog(LOG_INFO | LOG_USER, buf);
+    syslog(LOG_INFO | LOG_USER, "%s", buf);
 }
 
 static void log_syslog_free(void)


### PR DESCRIPTION
On glibc, syslog.h expects the first argument to be a format.
Autor:           Ildus Kurbangaliev <i.kurbangaliev@gmail.com>
Date:            Mon Dec 13 21:34:13 2021 +0500