### PR TITLE
src/postgres.c: fix gcc11 empty statement case warning

### DIFF
--- a/src/postgres.c
+++ b/src/postgres.c
@@ -67,8 +67,6 @@ _cpycmd(const char *host, const char *generation, postgres_format fmt)
         case POSTGRES_BINARY:
             format = "binary";
             break;
-        case POSTGRES_JSON:
-            __attribute__((fallthrough));
         default:
             format = "text";
             break;


### PR DESCRIPTION
gcc11s pedantic warnings do not like an empty fallthrough case.
Since we just want to jump to default, removing this case fixes the warning.

Author:           Ildus Kurbangaliev <i.kurbangaliev@gmail.com>
Date:             Wed Dec 15 07:02:48 2021 +0100