### PR TITLE
src/exports.c,src/hooks/jsonexport.c: fix uninitialised variable warning

### DIFF
--- a/src/exports.c
+++ b/src/exports.c
@@ -835,17 +835,17 @@ exporter_validate(UNUSED config_setting_t *config)
             if(filter_types[_filtertype_enum(filter)].needs_data) {
                 member = config_setting_get_elem(child,4);
                 if(member == NULL) {
-                    fprintf(stderr, "%s %d: filter needs configuration: %s\n",
-                    __FILE__, __LINE__, conf);
+                    fprintf(stderr, "%s %d: filter needs configuration\n",
+                    __FILE__, __LINE__);
                     goto error;
                 }
                 conf = config_setting_get_string(member);
                 if(conf == NULL) {
-                    fprintf(stderr, "%s %d: filter needs configuration: %s\n",
-                    __FILE__, __LINE__, conf);
+                    fprintf(stderr, "%s %d: filter needs configuration\n",
+                    __FILE__, __LINE__);
                     goto error;
                 }
-                    data = conf;
+                data = conf;
             }
         } else if (config_setting_is_group(child) == CONFIG_TRUE) {
             if(!CONF_L_IS_STRING(child, "jpointer", &jpointer, "failed to parse config"))

--- a/src/hooks/jsonexport.c
+++ b/src/hooks/jsonexport.c
@@ -747,14 +747,14 @@ h_jsonexport_validate(config_setting_t *config)
             if(filter_types[_filtertype_enum(filter)].needs_data) {
                 member = config_setting_get_elem(child,4);
                 if(member == NULL) {
-                    fprintf(stderr, "%s %d: filter needs configuration: %s\n",
-                    __FILE__, __LINE__, conf);
+                    fprintf(stderr, "%s %d: filter needs configuration\n",
+                    __FILE__, __LINE__);
                     goto error;
                 }
                 conf = config_setting_get_string(member);
                 if(conf == NULL) {
-                    fprintf(stderr, "%s %d: filter needs configuration: %s\n",
-                    __FILE__, __LINE__, conf);
+                    fprintf(stderr, "%s %d: filter needs configuration\n",
+                    __FILE__, __LINE__);
                     goto error;
                 }
                     data = conf;


### PR DESCRIPTION
This is a funny one. The analyzer only finds this condition when building with O2.

(cherry picked from commit 66b7ef9df0a8fc34dc224b4b7882f767584e960d)