### PR TITLE
Deprecate hash_r

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Schaufel is licensed for use as follows:
+
 MIT License
 
 Copyright (c) 2017 Robert Abraham
@@ -19,3 +21,50 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+The externally maintained libraries used by Schaufel are:
+ - c-alghoritms hash table by Aleksander Alekseev
+    BSD 2 Clause
+
+    Copyright (c) 2016, Aleksander Alekseev
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ - fnv32a by Landon Curt Noll
+    ***
+    *
+    * Please do not copyright this code.  This code is in the public domain.
+    *
+    * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+    * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
+    * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+    * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+    * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+    * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+    * PERFORMANCE OF THIS SOFTWARE.
+    *
+    * By:
+    *  chongo <Landon Curt Noll> /\oo/\
+    *      http://www.isthe.com/chongo/
+    *
+    * Share and Enjoy! :-)

--- a/configure.ac
+++ b/configure.ac
@@ -69,8 +69,6 @@ case "${CFLAGS}" in
         ;;
 esac
 AC_CHECK_FUNC(strdup,,AC_MSG_ERROR([can't find strdup!]))
-#todo: remove gnu extension asprintf
-AC_CHECK_FUNC(asprintf,,AC_MSG_ERROR([can't find asprintf!]))
 AC_CHECK_FUNC(getline,,AC_MSG_ERROR([can't find getline!]))
 #todo: remove gnu extension h*_r
 AC_CHECK_FUNC(hcreate_r,,AC_MSG_ERROR([can't find hcreate_r!]))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,6 +4,7 @@ schaufel_SOURCES = \
 	redis.c file.c kafka.c producer.c \
 	hooks/dummy.c hooks/jsonexport.c hooks/xmark.c \
 	utils/array.c utils/fnv.c utils/metadata.c utils/strlwr.c utils/bintree.c \
-	utils/helper.c utils/postgres.c utils/config.c utils/logger.c utils/scalloc.c
+	utils/helper.c utils/postgres.c utils/config.c utils/logger.c utils/scalloc.c \
+	utils/htable.c
 
 schaufel_LDFLAGS = @LIBS@

--- a/src/utils/fnv.c
+++ b/src/utils/fnv.c
@@ -1,3 +1,23 @@
+ /*
+ ***
+ *
+ * Please do not copyright this code.  This code is in the public domain.
+ *
+ * LANDON CURT NOLL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO
+ * EVENT SHALL LANDON CURT NOLL BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+ * USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ * By:
+ *	chongo <Landon Curt Noll> /\oo/\
+ *      http://www.isthe.com/chongo/
+ *
+ * Share and Enjoy!	:-)
+ */
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/utils/htable.c
+++ b/src/utils/htable.c
@@ -1,0 +1,253 @@
+/*
+ * htable.c
+ * (c) Alexandr A Alexeev 2011-2016 | http://eax.me/
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "utils/htable.h"
+
+#define MIN_HTABLE_SIZE (1 << 3)
+
+static void
+_htable_resize(HTable* tbl)
+{
+    HTableNode **new_items;
+    HTableNode *curr_item, *prev_item, *temp_item;
+    size_t item_idx, new_size = tbl->size;
+    uint32_t new_mask;
+
+    if(tbl->nitems < MIN_HTABLE_SIZE)
+        return;
+
+    if(tbl->nitems > tbl->size)
+    {
+        new_size = tbl->size * 2;
+        new_mask = new_size - 1;
+        new_items = tbl->allocfunc(sizeof(HTableNode*) * new_size, tbl->arg);
+        if(new_items == NULL)
+            return;
+
+        /* just copy first part of the `items` table */
+        memcpy(new_items, tbl->items, tbl->size * sizeof(HTableNode*));
+        /* second part fill with zeros for now */
+        memset(&new_items[tbl->size], 0, tbl->size * sizeof(HTableNode*));
+
+        for(item_idx = 0; item_idx < tbl->size; item_idx++)
+        {
+            prev_item = NULL;
+            curr_item = new_items[item_idx];
+            while(curr_item != NULL)
+            {
+                if((curr_item->hash & tbl->mask) != (curr_item->hash & new_mask))
+                {
+                    if(prev_item == NULL)
+                        new_items[item_idx] = curr_item->next;
+                    else
+                        prev_item->next = curr_item->next;
+
+                    temp_item = curr_item->next;
+                    curr_item->next = new_items[curr_item->hash & new_mask];
+                    new_items[curr_item->hash & new_mask] = curr_item;
+                    curr_item = temp_item;
+                }
+                else
+                {
+                    prev_item = curr_item;
+                    curr_item = curr_item->next;
+                }
+            } /* while */
+        } /* for */
+    }
+    else if(tbl->nitems <= (tbl->size / 2))
+    {
+        new_size = tbl->size / 2;
+        new_mask = new_size - 1;
+        new_items = tbl->allocfunc(sizeof(HTableNode*) * new_size, tbl->arg);
+        if(new_items == NULL)
+            return;
+
+        memcpy(new_items, tbl->items, new_size * sizeof(HTableNode*));
+        for(item_idx = new_size; item_idx < tbl->size; item_idx++)
+        {
+            if(tbl->items[item_idx] == NULL)
+                continue;
+
+            if(new_items[item_idx - new_size] == NULL)
+                new_items[item_idx - new_size] = tbl->items[item_idx];
+            else
+            {
+                curr_item = new_items[item_idx - new_size];
+                while(curr_item->next != NULL)
+                    curr_item = curr_item->next;
+                curr_item->next = tbl->items[item_idx];
+            }
+        }
+    }
+
+    if(new_size != tbl->size)
+    {
+        tbl->freefunc(tbl->items, tbl->arg);
+        tbl->items = new_items;
+        tbl->size = new_size;
+        tbl->mask = new_mask;
+    }
+}
+
+/* http://en.wikipedia.org/wiki/Jenkins_hash_function */
+uint32_t
+htable_default_hash(const char *key, const size_t key_len)
+{
+    uint32_t hash, i;
+
+    for(hash = i = 0; i < key_len; i++)
+    {
+        hash += key[i];
+        hash += (hash << 10);
+        hash ^= (hash >> 6);
+    }
+
+    hash += (hash << 3);
+    hash ^= (hash >> 11);
+    hash += (hash << 15);
+    return hash;
+}
+
+void
+htable_create(
+    HTable* tbl,
+    size_t node_size,
+    htable_hash_func hfunc,
+    htable_keyeq_func eqfunc,
+    htable_alloc_func allocfunc,
+    htable_free_func freefunc,
+    htable_before_node_free_func bnffunc,
+    void* arg)
+{
+    tbl->nitems = 0;
+    tbl->size = MIN_HTABLE_SIZE;
+    tbl->mask = tbl->size - 1;
+    tbl->node_size = node_size;
+    tbl->hfunc = hfunc;
+    tbl->eqfunc = eqfunc;
+    tbl->allocfunc = allocfunc;
+    tbl->freefunc = freefunc;
+    tbl->bnffunc = bnffunc;
+    tbl->arg = arg;
+
+    tbl->items = (HTableNode**)tbl->allocfunc(sizeof(HTableNode*) * tbl->size, tbl->arg);
+    if(tbl->items == NULL)
+        return;
+    memset(tbl->items, 0, sizeof(void*) * tbl->size);
+}
+
+void
+htable_free_items(HTable* tbl)
+{
+    size_t item_idx;
+    HTableNode *curr_item, *next_item;
+
+    for(item_idx = 0; item_idx < tbl->size; item_idx++)
+    {
+        curr_item = tbl->items[item_idx];
+        while(curr_item)
+        {
+            next_item = curr_item->next;
+            if(tbl->bnffunc)
+                tbl->bnffunc(curr_item, tbl->arg);
+            tbl->freefunc(curr_item, tbl->arg);
+            curr_item = next_item;
+        }
+    }
+
+    tbl->freefunc(tbl->items, tbl->arg);
+}
+
+HTableNode*
+htable_find(HTable* tbl, HTableNode* query)
+{
+    uint32_t hash = tbl->hfunc(query, tbl->arg);
+    HTableNode* curr_item = tbl->items[hash & tbl->mask];
+
+    while(curr_item)
+    {
+        if(tbl->eqfunc(curr_item, query, tbl->arg))
+            return curr_item;
+        curr_item = curr_item->next;
+    }
+
+    return NULL;
+}
+
+void
+htable_insert(HTable* tbl, HTableNode* node, bool* isNewNode)
+{
+    uint32_t hash = tbl->hfunc(node, tbl->arg);
+    HTableNode* item = tbl->items[hash & tbl->mask];
+
+    /* if such a key is already used, update node */
+    while(item)
+    {
+        if(tbl->eqfunc(item, node, tbl->arg))
+        {
+            HTableNode* savedNext = item->next;
+            if(tbl->bnffunc)
+                tbl->bnffunc(item, tbl->arg);
+            memcpy(item, node, tbl->node_size);
+            item->next = savedNext;
+            item->hash = hash;
+            *isNewNode = false;
+            return;
+        }
+        item = item->next;
+    }
+
+    /* key is not used yet, add new node */
+    item = tbl->allocfunc(tbl->node_size, tbl->arg);
+    if(item == NULL)
+        return;
+
+    memcpy(item, node, tbl->node_size);
+
+    item->hash = hash;
+    item->next = tbl->items[hash & tbl->mask];
+    tbl->items[hash & tbl->mask] = item;
+    tbl->nitems++;
+
+    _htable_resize(tbl);
+    *isNewNode = true;
+}
+
+bool
+htable_delete(HTable* tbl, HTableNode* query)
+{
+    uint32_t hash = tbl->hfunc(query, tbl->arg);
+    HTableNode* item = tbl->items[hash & tbl->mask];
+    HTableNode* prev = NULL;
+
+    while(item)
+    {
+        if(tbl->eqfunc(item, query, tbl->arg))
+        {
+            if(prev)
+                prev->next = item->next;
+            else
+                tbl->items[hash & tbl->mask] = item->next;
+
+            if(tbl->bnffunc)
+                tbl->bnffunc(item, tbl->arg);
+            tbl->freefunc(item, tbl->arg);
+            tbl->nitems--;
+            _htable_resize(tbl);
+            return true;
+        }
+        prev = item;
+        item = item->next;
+    }
+
+    return false;
+}
+

--- a/src/utils/htable.h
+++ b/src/utils/htable.h
@@ -1,0 +1,60 @@
+/*
+ * htable.h
+ * (c) Alexandr A Alexeev 2011-2016 | http://eax.me/
+ */
+#ifndef _SCHAUFEL_UTIL_HTABLE_H_
+#define _SCHAUFEL_UTIL_HTABLE_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct HTableNode
+{
+    struct HTableNode* next;    /* next node in a chain, if any */
+    uint32_t hash;              /* hash function value */
+} HTableNode;
+
+typedef uint32_t (*htable_hash_func) (const HTableNode* a, void *arg);
+typedef bool (*htable_keyeq_func) (const HTableNode* a, const HTableNode* b, void *arg);
+typedef void* (*htable_alloc_func) (size_t size, void *arg);
+typedef void (*htable_free_func) (void* mem, void *arg);
+typedef void (*htable_before_node_free_func) (HTableNode* node, void *arg);
+
+/* Hash table representation */
+typedef struct {
+    HTableNode** items; /* table items */
+    size_t nitems;      /* how many items are stored in hash table */
+    uint32_t mask;      /* mask, aplied to hash function */
+    size_t size;        /* current hash table size */
+
+    /* user-specified arguments */
+
+    size_t node_size;
+    htable_hash_func hfunc;
+    htable_keyeq_func eqfunc;
+    htable_alloc_func allocfunc;
+    htable_free_func freefunc;
+    htable_before_node_free_func bnffunc;
+    void* arg;
+} HTable;
+
+extern uint32_t htable_default_hash(const char *key, const size_t key_len);
+extern void htable_create(
+        HTable* tbl,
+        size_t node_size,
+        htable_hash_func hfunc,
+        htable_keyeq_func eqfunc,
+        htable_alloc_func allocfunc,
+        htable_free_func freefunc,
+        htable_before_node_free_func bnffunc,
+        void* arg
+    );
+extern void htable_free_items(HTable* tbl);
+extern HTableNode* htable_find(HTable* tbl, HTableNode* query);
+extern void htable_insert(HTable* tbl, HTableNode* node, bool* isNewNode);
+extern bool htable_delete(HTable* tbl, HTableNode* query);
+
+#define htable_nitems(tbl) ((tbl)->nitems)
+
+#endif

--- a/src/utils/metadata.c
+++ b/src/utils/metadata.c
@@ -22,8 +22,7 @@ mdatum_free(HTableNode* n, UNUSED void *arg)
 {
     MDatum m = (MDatum) n;
 
-    if(m->type == MTYPE_STRING)
-        free(m->value);
+    free(m->value);
     return;
 }
 

--- a/src/utils/metadata.c
+++ b/src/utils/metadata.c
@@ -56,7 +56,7 @@ static uint32_t
 _hash_func(const HTableNode *a_, UNUSED void *arg)
 {
     MDatum a = (MDatum)a_;
-    return htable_default_hash(a->key, sizeof(a->key));
+    return htable_default_hash(a->key, strlen(a->key));
 }
 
 /*

--- a/src/utils/metadata.h
+++ b/src/utils/metadata.h
@@ -14,15 +14,6 @@ typedef enum {
     MTYPE_BIGINT
 } MTypes;
 
-/*
-typedef struct
-{
-	HTableNode node;
-	char expression[128];
-	int value;
-} ExpressionTableNodeData;
-*/
-
 typedef struct mdatum {
     HTableNode node;
     char      *key;
@@ -31,11 +22,8 @@ typedef struct mdatum {
     MTypes     type;
 } *MDatum;
 
-typedef struct Metadata {
-//    MDatum *mdata;
-//    uint8_t nel;
-    HTable *htab;
-} *Metadata;
+/* alias htable pointer as Metadata */
+typedef struct HTable *Metadata;
 
 MDatum metadata_find(Metadata *m, char *key);
 MDatum metadata_insert(Metadata *m, char *key, MDatum datum);

--- a/src/utils/metadata.h
+++ b/src/utils/metadata.h
@@ -2,7 +2,9 @@
 #define _SCHAUFEL_UTILS_METADATA_H
 
 #include "../schaufel.h"
+#include "utils/htable.h"
 #include <stdint.h>
+
 
 #define MAXELEM 8
 
@@ -12,16 +14,27 @@ typedef enum {
     MTYPE_BIGINT
 } MTypes;
 
+/*
+typedef struct
+{
+	HTableNode node;
+	char expression[128];
+	int value;
+} ExpressionTableNodeData;
+*/
+
 typedef struct mdatum {
-    void    *value;
-    uint64_t len;
-    MTypes   type;
+    HTableNode node;
+    char      *key;
+    void      *value;
+    uint64_t   len;
+    MTypes     type;
 } *MDatum;
 
 typedef struct Metadata {
-    MDatum *mdata;
-    uint8_t nel;
-    struct hsearch_data *htab;
+//    MDatum *mdata;
+//    uint8_t nel;
+    HTable *htab;
 } *Metadata;
 
 MDatum metadata_find(Metadata *m, char *key);

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -1,12 +1,14 @@
 check_PROGRAMS = dummy_consumer_test jsonexports_test parse_hostinfo array \
 		dummy_producer_test logger_test queue_test bintree_test \
 		file_consumer_test logparse_test strlwr_test config_merge_test \
-		fnv_test metadata_test config_test hooks_test parse_connstring
+		fnv_test metadata_test config_test hooks_test parse_connstring \
+		htable_test
+
 TESTS = $(check_PROGRAMS)
 
 test : check-am
 
-common_sources = $(top_builddir)/src/utils/config.c $(top_builddir)/src/queue.c $(top_builddir)/src/consumer.c $(top_builddir)/src/producer.c $(top_builddir)/src/hooks.c $(top_builddir)/src/validator.c $(top_builddir)/src/utils/logger.c $(top_builddir)/src/utils/scalloc.c $(top_builddir)/src/hooks/dummy.c $(top_builddir)/src/hooks/xmark.c $(top_builddir)/src/hooks/jsonexport.c $(top_builddir)/src/utils/metadata.c $(top_builddir)/src/utils/fnv.c $(top_builddir)/src/utils/bintree.c $(top_builddir)/src/file.c $(top_builddir)/src/exports.c $(top_builddir)/src/postgres.c $(top_builddir)/src/redis.c $(top_builddir)/src/kafka.c $(top_builddir)/src/utils/helper.c $(top_builddir)/src/utils/array.c $(top_builddir)/src/utils/postgres.c $(top_builddir)/src/dummy.c $(top_builddir)/src/utils/strlwr.c
+common_sources = $(top_builddir)/src/utils/config.c $(top_builddir)/src/queue.c $(top_builddir)/src/consumer.c $(top_builddir)/src/producer.c $(top_builddir)/src/hooks.c $(top_builddir)/src/validator.c $(top_builddir)/src/utils/logger.c $(top_builddir)/src/utils/scalloc.c $(top_builddir)/src/hooks/dummy.c $(top_builddir)/src/hooks/xmark.c $(top_builddir)/src/hooks/jsonexport.c $(top_builddir)/src/utils/metadata.c $(top_builddir)/src/utils/fnv.c $(top_builddir)/src/utils/bintree.c $(top_builddir)/src/file.c $(top_builddir)/src/exports.c $(top_builddir)/src/postgres.c $(top_builddir)/src/redis.c $(top_builddir)/src/kafka.c $(top_builddir)/src/utils/helper.c $(top_builddir)/src/utils/array.c $(top_builddir)/src/utils/postgres.c $(top_builddir)/src/dummy.c $(top_builddir)/src/utils/strlwr.c $(top_builddir)/src/utils/htable.c
 
 dummy_consumer_test_SOURCES = $(common_sources) dummy_consumer_test.c
 dummy_producer_test_SOURCES = $(common_sources) jsonexports_test.c
@@ -25,3 +27,4 @@ fnv_test_SOURCES = $(common_sources) fnv_test.c
 metadata_test_SOURCES = $(common_sources) metadata_test.c
 hooks_test_SOURCES = $(common_sources) hooks_test.c
 parse_connstring_SOURCES = $(common_sources) parse_connstring.c
+htable_test_SOURCES = $(common_sources) htable_test.c

--- a/t/htable_test.c
+++ b/t/htable_test.c
@@ -1,0 +1,125 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "test/test.h"
+#include "utils/htable.h"
+
+#define N 100
+
+typedef struct
+{
+	HTableNode node;
+	char expression[128];
+	int value;
+} ExpressionTableNodeData;
+
+typedef ExpressionTableNodeData *ExpressionTableNode;
+
+static bool
+keyeq_func(const HTableNode* a_, const HTableNode* b_, void *arg)
+{
+	ExpressionTableNode a = (ExpressionTableNode)a_;
+	ExpressionTableNode b = (ExpressionTableNode)b_;
+	return (strcmp(a->expression, b->expression) == 0);
+}
+
+static uint32_t
+hash_func(const HTableNode* a_, void *arg)
+{
+	ExpressionTableNode a = (ExpressionTableNode)a_;
+	return htable_default_hash(a->expression, strlen(a->expression));
+}
+
+static void*
+alloc_func(size_t size, void *arg)
+{
+	return malloc(size);
+}
+
+static void
+free_func(void* mem, void *arg)
+{
+	free(mem);
+}
+
+static void
+run_test(HTable* htable)
+{
+	int i, j;
+
+	/* fill table */
+	for(i = 1; i <= N; i++)
+	{
+		for(j = 1; j <= N; j++)
+		{
+			bool isNewNode;
+			ExpressionTableNodeData new_node_data;
+			sprintf(new_node_data.expression, "%d + %d", i, j);
+			new_node_data.value = (i + j);
+			htable_insert(htable, (HTableNode*)&new_node_data, &isNewNode);
+			pretty_assert(isNewNode);
+		}
+	}
+
+	pretty_assert(htable_nitems(htable) == (N*N));
+
+	/* check hash table is filled right */
+	for(i = 1; i <= N; i++)
+	{
+		for(j = 1; j <= N; j++)
+		{
+			ExpressionTableNode found_node;
+			ExpressionTableNodeData query;
+			sprintf(query.expression, "%d + %d", i, j);
+			found_node = (ExpressionTableNode)htable_find(htable, (HTableNode*)&query);
+			pretty_assert(found_node != NULL);
+			pretty_assert(found_node->value == (i + j));
+		}
+	}
+
+	/* try to delete a non-existing node */
+	{
+		bool result;
+		ExpressionTableNodeData query;
+		sprintf(query.expression, "ololo trololo");
+		result = htable_delete(htable, (HTableNode*)&query);
+		pretty_assert(result == false);
+	}
+
+	/* clean table */
+	for(i = 1; i <= N; i++)
+	{
+		for(j = 1; j <= N; j++)
+		{
+			bool result;
+			ExpressionTableNodeData query;
+			sprintf(query.expression, "%d + %d", i, j);
+			result = htable_delete(htable, (HTableNode*)&query);
+			pretty_assert(result == true);
+		}
+	}
+
+	pretty_assert(htable_nitems(htable) == 0);
+}
+
+int main()
+{
+	int i;
+	HTable htable_data;
+
+	htable_create(
+			&htable_data,
+			sizeof(ExpressionTableNodeData),
+			hash_func,
+			keyeq_func,
+			alloc_func,
+			free_func,
+			NULL,
+			NULL
+		);
+
+	run_test(&htable_data);
+
+	return 0;
+}

--- a/t/htable_test.c
+++ b/t/htable_test.c
@@ -9,9 +9,9 @@
 
 typedef struct
 {
-	HTableNode node;
-	char expression[128];
-	int value;
+    HTableNode node;
+    char expression[128];
+    int value;
 } ExpressionTableNodeData;
 
 typedef ExpressionTableNodeData *ExpressionTableNode;
@@ -19,108 +19,108 @@ typedef ExpressionTableNodeData *ExpressionTableNode;
 static bool
 keyeq_func(const HTableNode* a_, const HTableNode* b_, void *arg)
 {
-	ExpressionTableNode a = (ExpressionTableNode)a_;
-	ExpressionTableNode b = (ExpressionTableNode)b_;
-	return (strcmp(a->expression, b->expression) == 0);
+    ExpressionTableNode a = (ExpressionTableNode)a_;
+    ExpressionTableNode b = (ExpressionTableNode)b_;
+    return (strcmp(a->expression, b->expression) == 0);
 }
 
 static uint32_t
 hash_func(const HTableNode* a_, void *arg)
 {
-	ExpressionTableNode a = (ExpressionTableNode)a_;
-	return htable_default_hash(a->expression, strlen(a->expression));
+    ExpressionTableNode a = (ExpressionTableNode)a_;
+    return htable_default_hash(a->expression, strlen(a->expression));
 }
 
 static void*
 alloc_func(size_t size, void *arg)
 {
-	return malloc(size);
+    return malloc(size);
 }
 
 static void
 free_func(void* mem, void *arg)
 {
-	free(mem);
+    free(mem);
 }
 
 static void
 run_test(HTable* htable)
 {
-	int i, j;
+    int i, j;
 
-	/* fill table */
-	for(i = 1; i <= N; i++)
-	{
-		for(j = 1; j <= N; j++)
-		{
-			bool isNewNode;
-			ExpressionTableNodeData new_node_data;
-			sprintf(new_node_data.expression, "%d + %d", i, j);
-			new_node_data.value = (i + j);
-			htable_insert(htable, (HTableNode*)&new_node_data, &isNewNode);
-			pretty_assert(isNewNode);
-		}
-	}
+    /* fill table */
+    for(i = 1; i <= N; i++)
+    {
+        for(j = 1; j <= N; j++)
+        {
+            bool isNewNode;
+            ExpressionTableNodeData new_node_data;
+            sprintf(new_node_data.expression, "%d + %d", i, j);
+            new_node_data.value = (i + j);
+            htable_insert(htable, (HTableNode*)&new_node_data, &isNewNode);
+            pretty_assert(isNewNode);
+        }
+    }
 
-	pretty_assert(htable_nitems(htable) == (N*N));
+    pretty_assert(htable_nitems(htable) == (N*N));
 
-	/* check hash table is filled right */
-	for(i = 1; i <= N; i++)
-	{
-		for(j = 1; j <= N; j++)
-		{
-			ExpressionTableNode found_node;
-			ExpressionTableNodeData query;
-			sprintf(query.expression, "%d + %d", i, j);
-			found_node = (ExpressionTableNode)htable_find(htable, (HTableNode*)&query);
-			pretty_assert(found_node != NULL);
-			pretty_assert(found_node->value == (i + j));
-		}
-	}
+    /* check hash table is filled right */
+    for(i = 1; i <= N; i++)
+    {
+        for(j = 1; j <= N; j++)
+        {
+            ExpressionTableNode found_node;
+            ExpressionTableNodeData query;
+            sprintf(query.expression, "%d + %d", i, j);
+            found_node = (ExpressionTableNode)htable_find(htable, (HTableNode*)&query);
+            pretty_assert(found_node != NULL);
+            pretty_assert(found_node->value == (i + j));
+        }
+    }
 
-	/* try to delete a non-existing node */
-	{
-		bool result;
-		ExpressionTableNodeData query;
-		sprintf(query.expression, "ololo trololo");
-		result = htable_delete(htable, (HTableNode*)&query);
-		pretty_assert(result == false);
-	}
+    /* try to delete a non-existing node */
+    {
+        bool result;
+        ExpressionTableNodeData query;
+        sprintf(query.expression, "ololo trololo");
+        result = htable_delete(htable, (HTableNode*)&query);
+        pretty_assert(result == false);
+    }
 
-	/* clean table */
-	for(i = 1; i <= N; i++)
-	{
-		for(j = 1; j <= N; j++)
-		{
-			bool result;
-			ExpressionTableNodeData query;
-			sprintf(query.expression, "%d + %d", i, j);
-			result = htable_delete(htable, (HTableNode*)&query);
-			pretty_assert(result == true);
-		}
-	}
+    /* clean table */
+    for(i = 1; i <= N; i++)
+    {
+        for(j = 1; j <= N; j++)
+        {
+            bool result;
+            ExpressionTableNodeData query;
+            sprintf(query.expression, "%d + %d", i, j);
+            result = htable_delete(htable, (HTableNode*)&query);
+            pretty_assert(result == true);
+        }
+    }
 
-	pretty_assert(htable_nitems(htable) == 0);
+    pretty_assert(htable_nitems(htable) == 0);
 }
 
 int main()
 {
-	int i;
-	HTable htable_data;
+    int i;
+    HTable htable_data;
 
-	htable_create(
-			&htable_data,
-			sizeof(ExpressionTableNodeData),
-			hash_func,
-			keyeq_func,
-			alloc_func,
-			free_func,
-			NULL,
-			NULL
-		);
+    htable_create(
+            &htable_data,
+            sizeof(ExpressionTableNodeData),
+            hash_func,
+            keyeq_func,
+            alloc_func,
+            free_func,
+            NULL,
+            NULL
+        );
 
-	run_test(&htable_data);
+    run_test(&htable_data);
     htable_free_items(&htable_data);
 
-	return 0;
+    return 0;
 }

--- a/t/htable_test.c
+++ b/t/htable_test.c
@@ -4,8 +4,9 @@
 #include <unistd.h>
 #include "test/test.h"
 #include "utils/htable.h"
+#include "utils/helper.h"
 
-#define N 100
+#define N 10
 
 typedef struct
 {
@@ -17,7 +18,7 @@ typedef struct
 typedef ExpressionTableNodeData *ExpressionTableNode;
 
 static bool
-keyeq_func(const HTableNode* a_, const HTableNode* b_, void *arg)
+keyeq_func(const HTableNode* a_, const HTableNode* b_, UNUSED void *arg)
 {
     ExpressionTableNode a = (ExpressionTableNode)a_;
     ExpressionTableNode b = (ExpressionTableNode)b_;
@@ -25,20 +26,20 @@ keyeq_func(const HTableNode* a_, const HTableNode* b_, void *arg)
 }
 
 static uint32_t
-hash_func(const HTableNode* a_, void *arg)
+hash_func(const HTableNode* a_, UNUSED void *arg)
 {
     ExpressionTableNode a = (ExpressionTableNode)a_;
     return htable_default_hash(a->expression, strlen(a->expression));
 }
 
 static void*
-alloc_func(size_t size, void *arg)
+alloc_func(size_t size, UNUSED void *arg)
 {
     return malloc(size);
 }
 
 static void
-free_func(void* mem, void *arg)
+free_func(void* mem, UNUSED void *arg)
 {
     free(mem);
 }
@@ -105,7 +106,6 @@ run_test(HTable* htable)
 
 int main()
 {
-    int i;
     HTable htable_data;
 
     htable_create(
@@ -120,6 +120,7 @@ int main()
         );
 
     run_test(&htable_data);
+    /* Todo: there shouldn't be any item remaining */
     htable_free_items(&htable_data);
 
     return 0;

--- a/t/htable_test.c
+++ b/t/htable_test.c
@@ -120,6 +120,7 @@ int main()
 		);
 
 	run_test(&htable_data);
+    htable_free_items(&htable_data);
 
 	return 0;
 }

--- a/t/metadata_test.c
+++ b/t/metadata_test.c
@@ -16,6 +16,7 @@ int main()
     MDatum md1 = mdatum_init(MTYPE_STRING,strdup("hurz"),strlen("hurz"));
     res = metadata_insert(&meta,"1",md1);
     pretty_assert(res != NULL);
+    if (res == NULL) goto error;
     pretty_assert(strncmp(res->value,"hurz",4) == 0);
     MDatum md2 = mdatum_init(MTYPE_STRING,strdup("huch"),strlen("huch"));
     metadata_insert(&meta,"2",md2);
@@ -30,16 +31,19 @@ int main()
     MDatum md7 = mdatum_init(MTYPE_INT,num,sizeof(*num));
     metadata_insert(&meta,"7",md7);
 
+    /*
     // Test max elements (8)
     MDatum md8 = mdatum_init(MTYPE_STRING,strdup("qoui"),strlen("quoi"));
     res = metadata_insert(&meta,"8",md8);
     pretty_assert(res != NULL);
-    res = metadata_insert(&meta,"9",md8);
-    pretty_assert(res == NULL);
+    //res = metadata_insert(&meta,"9",md8);
+    //pretty_assert(res == NULL);
+    */
 
     // Find integer
     res = metadata_find(&meta,"7");
     pretty_assert(res != NULL);
+    if (res == NULL) goto error;
     pretty_assert(res->type == MTYPE_INT);
     pretty_assert((*(uint32_t *)(res->value)) == 0xffff);
 
@@ -49,6 +53,7 @@ int main()
     pretty_assert(res->type == MTYPE_STRING);
     pretty_assert(strncmp(res->value,"argh",4) == 0);
 
+    error:
     metadata_free(&meta);
     return 0;
 }


### PR DESCRIPTION
hash_r is a gnu extension, and we're trying to not have those.

I've deprecated it by using hash_table from http://eax.me/. A bit overkill, but it supports dynamic resizing and is reasonably easy to read.
It's BSD-2 clause and as such compatible with both GPL and MIT.