### PR TITLE
t/dummy_consumer_test.c: fix indentation and error path

### DIFF
--- a/t/dummy_consumer_test.c
+++ b/t/dummy_consumer_test.c
@@ -18,12 +18,23 @@ main(void)
     consumer_consume(c, msg);
     char *string =(char *) message_get_data(msg);
     pretty_assert(string != NULL);
-    if (string != NULL)
+    if (string != NULL) {
         pretty_assert(strncmp(string, "{\"type\":\"dummy\"}", 16) == 0);
         printf("%s\n", string);
+    } else
+        goto error;
     message_free(&msg);
     free(string);
     consumer_free(&c);
     config_destroy(&conf_root);
+
     return 0;
+
+    error:
+    message_free(&msg);
+    free(string);
+    consumer_free(&c);
+    config_destroy(&conf_root);
+
+    return 1;
 }


### PR DESCRIPTION
This test has had missing curly braces and didn't error out since 2017.
Fixed.