### PR TITLE
Freebsd portability

### DIFF
--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 #include <stdarg.h>
 #include <stdatomic.h>


### PR DESCRIPTION
Freebsd doesn't expect fcntl.h to define S_ISUID & co. There's no harm in including sys/types.h unconditionally.