### PR TITLE
Kafka simple consumer and per partition assignment.

### DIFF
--- a/src/kafka.c
+++ b/src/kafka.c
@@ -2,6 +2,7 @@
 #include <librdkafka/rdkafka.h>
 #include <stdbool.h>
 #include <string.h>
+#include <regex.h>
 
 #include "kafka.h"
 #include "utils/config.h"
@@ -127,6 +128,73 @@ static void kafka_set_option(const char *key, const char *value, void *arg)
     }
 }
 
+static int32_t *explode_partitions(const char *parts)
+{
+    int32_t *p = SCALLOC(sizeof(p),8192);
+    int32_t *start = p;
+    if(!parts)
+    {
+        logger_log("%s %d: partition list undefined!", __FILE__, __LINE__);
+        abort();
+    }
+    int err = errno;
+    uint32_t count = 0;
+    errno = 0;
+
+    while(*parts)
+    {
+        uint64_t a = 0, b = 0;
+        char *endptr = NULL;
+
+        a = strtoul(parts, &endptr, 0);
+        if(*endptr == '-')
+        {
+            b = strtoul(++endptr, &endptr, 0);
+        }
+        else if(endptr == parts)
+        {
+            logger_log("%s %d: invalid token: %s",
+                __FILE__, __LINE__, parts);
+             abort();
+        }
+        else
+            b = a;
+
+        if(a > b)
+        {
+            a = a+b;
+            b = a-b;
+            a = a-b;
+        }
+
+        if(errno)
+        {
+            logger_log("%s %d: partition out of range %s",
+                __FILE__, __LINE__, parts);
+            abort();
+        }
+
+        while(a <= b)
+        {
+            *p = a++;
+            p++;
+            count++;
+            if(count > 8190)
+            {
+                logger_log("%s %d: manual assignment of more than 8000 "
+                    "partitions? Did you mean to do that?",
+                    __FILE__, __LINE__);
+                abort();
+            }
+        }
+        parts = endptr;
+    }
+    *p = -1;
+    errno = err;
+
+    return start;
+}
+
 static void kafka_topic_set_option(const char *key, const char *value, void *arg)
 {
     char errstr[512];
@@ -175,6 +243,7 @@ typedef struct Meta {
     rd_kafka_topic_t *rkt;
     rd_kafka_conf_t *conf;
     rd_kafka_topic_partition_list_t *topics;
+    rd_kafka_queue_t *rkqu;
 } *Meta;
 
 Meta
@@ -234,23 +303,27 @@ kafka_producer_meta_init(const char *broker,
 Meta
 kafka_consumer_meta_init(const char *broker,
                          const char *topic,
+                         const int32_t *partarray,
                          const char *groupid,
                          const config_setting_t *kafka_options,
                          const config_setting_t *topic_options)
 {
     Meta m = SCALLOC(1, sizeof(*m));
     char errstr[512];
+    const int32_t          *partcopy = partarray;
     rd_kafka_resp_err_t     err;
     rd_kafka_t             *rk;
     rd_kafka_topic_t       *rkt;
     rd_kafka_conf_t        *conf;
     rd_kafka_topic_conf_t  *topic_conf;
+    rd_kafka_queue_t       *rkqu = NULL;
 
     conf = rd_kafka_conf_new();
     rd_kafka_conf_set_opaque(conf, (void *) broker);
     config_group_apply(kafka_options, kafka_set_option, conf);
 
-    if (rd_kafka_conf_set(conf, "group.id", groupid, errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    if (groupid && rd_kafka_conf_set(conf, "group.id", groupid, errstr,
+        sizeof(errstr)) != RD_KAFKA_CONF_OK)
     {
         logger_log("%s %d: %s: %s", __FILE__, __LINE__, broker, errstr);
         abort();
@@ -263,16 +336,15 @@ kafka_consumer_meta_init(const char *broker,
     rd_kafka_conf_set_offset_commit_cb(conf, offset_commit_cb);
     rd_kafka_conf_set_rebalance_cb(conf, rebalance_cb);
     rd_kafka_conf_set_error_cb(conf, err_cb);
+
+    rd_kafka_conf_set(conf, "metadata.broker.list",
+        broker, errstr, sizeof(errstr));
+
     rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr));
     if (!rk)
     {
         logger_log("%s %d: %s: Failed to create new consumer: %s\n",
             __FILE__, __LINE__, broker, errstr);
-        abort();
-    }
-
-    if (rd_kafka_brokers_add(rk, broker) == 0)
-    {
         abort();
     }
 
@@ -288,19 +360,34 @@ kafka_consumer_meta_init(const char *broker,
     rd_kafka_poll_set_consumer(rk);
 
     rd_kafka_topic_partition_list_t *topics = rd_kafka_topic_partition_list_new(1);
-    rd_kafka_topic_partition_list_add(topics, topic, -1);
+    if(partarray) /* Simple Consumer */
+    {
+        rkqu = rd_kafka_queue_new(rk);
+        while((*partarray) > -1)
+        {
+            rd_kafka_topic_partition_list_add(topics, topic, *partarray);
+            rd_kafka_consume_start_queue(rkt, *partarray, RD_KAFKA_OFFSET_END, rkqu);
+            partarray++;
+        }
+        partarray = partcopy;
+    }
+    else
+        rd_kafka_topic_partition_list_add(topics, topic, -1);
 
-    if ((err = rd_kafka_subscribe(rk, topics)))
+    /* High level Consumer */
+    if (groupid && (err = rd_kafka_subscribe(rk, topics)))
     {
             fprintf(stderr,
                     "%% Failed to start consuming topics: %s\n",
                     rd_kafka_err2str(err));
             abort();
     }
+
     m->rk = rk;
     m->rkt = rkt;
     m->conf = conf;
     m->topics = topics;
+    m->rkqu = rkqu;
     return m;
 }
 
@@ -322,6 +409,7 @@ kafka_consumer_meta_free(Meta *m)
     rd_kafka_topic_partition_list_destroy((*m)->topics);
     rd_kafka_topic_destroy((*m)->rkt);
     rd_kafka_destroy((*m)->rk);
+    rd_kafka_queue_destroy((*m)->rkqu);
     free(*m);
     *m = NULL;
 }
@@ -398,24 +486,32 @@ Consumer
 kafka_consumer_init(config_setting_t *config)
 {
     const char *broker = NULL, *topic = NULL, *groupid = NULL;
-    config_setting_t *kafka_options, *topic_options;
-
+    config_setting_t *kafka_options, *topic_options, *kpart = NULL;
+    int32_t *partarray = NULL;
     kafka_consumer_defaults(config);
 
     config_setting_lookup_string(config, "broker", &broker);
     config_setting_lookup_string(config, "topic", &topic);
     config_setting_lookup_string(config, "groupid", &groupid);
+
+    if((kpart = config_setting_lookup(config, "partitions")))
+        partarray = explode_partitions(config_setting_get_string(kpart)); 
+
     kafka_options = config_setting_get_member(config, "kafka_options");
     topic_options = config_setting_get_member(config, "topic_options");
 
     Consumer kafka = SCALLOC(1, sizeof(*kafka));
 
-    kafka->meta = kafka_consumer_meta_init(broker, topic, groupid,
+    kafka->meta = kafka_consumer_meta_init(broker, topic, partarray, groupid,
                                            kafka_options,
                                            topic_options);
     kafka->consumer_free = kafka_consumer_free;
-    kafka->consume = kafka_consumer_consume;
+    if(groupid)
+        kafka->consume = kafka_consumer_consume;
+    else
+        kafka->consume = kafka_simple_consumer_consume;
 
+    free(partarray);
     return kafka;
 }
 
@@ -436,6 +532,46 @@ void _rkmessage_log(rd_kafka_message_t *rkmessage)
             rd_kafka_err2str(rkmessage->err),
             rd_kafka_message_errstr(rkmessage));
     return;
+}
+
+int
+kafka_simple_consumer_consume(Consumer c, Message msg)
+{
+    rd_kafka_queue_t *rkqu = ((Meta) c->meta)->rkqu;
+    rd_kafka_message_t *rkmessage;
+
+    rkmessage = rd_kafka_consume_queue(rkqu, 10000);
+
+    if (!rkmessage)
+        return 0;
+
+    if (rkmessage->err)
+    {
+        switch(rkmessage->err)
+        {
+            case RD_KAFKA_RESP_ERR__PARTITION_EOF:
+                break;
+
+            case RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION:
+            case RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC:
+                _rkmessage_log(rkmessage);
+                abort();
+                break;
+
+            default:
+                _rkmessage_log(rkmessage);
+        }
+        rd_kafka_message_destroy(rkmessage);
+        return 0;
+    }
+
+    char *cpy = SCALLOC((int)rkmessage->len + 1, sizeof(*cpy));
+    memcpy(cpy, (char *)rkmessage->payload, (size_t)rkmessage->len);
+    message_set_data(msg, cpy);
+    message_set_len(msg, (size_t)rkmessage->len);
+    rd_kafka_message_destroy(rkmessage);
+
+    return 0;
 }
 
 int
@@ -491,13 +627,171 @@ bool
 kafka_validator(config_setting_t *config)
 {
     const char *result = NULL;
+    regex_t top_par = {0};
+    regmatch_t pmatch[20] = {0};
+    int res = 0;
+
     if(!CONF_L_IS_STRING(config, "broker", &result, "kafka: need a broker!"))
         return false;
     result = NULL;
+
+    if(config_setting_type(config_setting_lookup(config, "topic")) ==
+        CONFIG_TYPE_LIST)
+    {
+        // not implemented
+        goto error;
+    }
     if(!CONF_L_IS_STRING(config, "topic", &result, "kafka: need a topic!"))
-        return false;
+        goto error;
+
+    /*  grammar of kafka names:
+     *  ^([[:alpha:]._-]+)(:([0-9]+(-[0-9]+)?,?)+)?$
+     *  kafka takes an alphanumeric string with .-_
+     *  optionally, we can specify partion numbers after :
+     *  e.g.
+     *  kafka.topic.events.3:0-5,7,9,13
+     */
+
+    res = regcomp(&top_par,
+        "^([[:alnum:]._-]+)(:([0-9]+(-[0-9]+)?,?))+)?$", REG_EXTENDED);
+
+    if(res)
+    {
+        char buf[512] = {0};
+        regerror(res,&top_par,buf,sizeof(buf));
+        fprintf(stderr, "%s %d: compiling kafka topic/partition regex failed: %s\n",
+            __FILE__, __LINE__, buf);
+
+        goto error;
+    }
+
+    if(regexec(&top_par, result, sizeof(pmatch)/sizeof(pmatch[0]),
+        pmatch, 0) == REG_NOMATCH)
+    {
+        fprintf(stderr, "%s %d: %s isn't a kafka topic/partition name\n",
+            __FILE__, __LINE__, result);
+            goto error;
+    }
+    regfree(&top_par);
+
+    // we have found a partition specifier
+    if(pmatch[2].rm_so > 0)
+    {
+        // Truncate the string in the hackiest way possible
+        *(char *) (result+pmatch[2].rm_so) = '\0';
+
+        config_setting_t *partitions = NULL;
+        if((partitions = config_setting_get_member(config, "partitions")))
+        {
+            fprintf(stderr, "%s %d: partitions already specified in topic"
+                " with partitions\n", __FILE__, __LINE__);
+            goto error;
+        }
+        partitions = config_setting_add(config, "partitions", CONFIG_TYPE_STRING);
+        if(!partitions)
+        {
+            fprintf(stderr, "%s %d: failed to alloc config setting!\n",
+                __FILE__, __LINE__);
+            abort();
+        }
+        config_setting_set_string(partitions, result+pmatch[3].rm_so);
+
+        /* The high level consumer will rebalance */
+        fprintf(stderr, "%s %d: Manual partition assignment found. "
+            "Disabling librdkafka high level consumer\n", __FILE__, __LINE__);
+
+        config_setting_t *kopts = NULL, *auto_commit = NULL;
+        if(!(kopts = config_setting_lookup(config, "kafka_options")))
+        {
+            kopts = config_setting_add(config, "kafka_options", CONFIG_TYPE_GROUP);
+            auto_commit = config_setting_add(kopts,
+                "enable_auto_commit", CONFIG_TYPE_STRING);
+            config_setting_set_string(auto_commit, "false");
+        }
+        else if(config_setting_type(kopts) != CONFIG_TYPE_GROUP)
+        {
+            fprintf(stderr, "%s %d: kafka_options must be a group type!\n",
+                __FILE__, __LINE__);
+            goto error;
+        }
+        else
+        {
+            auto_commit = config_setting_get_member(kopts, "enable_auto_commit");
+            if(!auto_commit) {
+                auto_commit =  config_setting_add(kopts, "enable_auto_commit",
+                    CONFIG_TYPE_STRING);
+            }
+            config_setting_set_string(auto_commit, "false");
+        }
+
+
+    }
+
+    config_setting_t *partitions = NULL;
+    if((partitions = config_setting_get_member(config, "partitions")))
+    {
+        if(config_setting_type(partitions) == CONFIG_TYPE_STRING)
+        {
+            const char *p = config_setting_get_string(partitions);
+            regex_t par;
+
+            res = regcomp(&par, "^([0-9]+(-[0-9]+)?,?)+?$",
+                REG_EXTENDED | REG_NOSUB);
+
+            if(res)
+            {
+                char buf[512] = {0};
+                regerror(res,&par,buf,sizeof(buf));
+                fprintf(stderr, "%s %d: compiling kafka partition regex failed:"
+                    " %s\n", __FILE__, __LINE__, buf);
+                regfree(&par);
+
+                goto error;
+            }
+            if(regexec(&par, p, 0, NULL, 0) == REG_NOMATCH)
+            {
+                fprintf(stderr, "%s %d: invalid partition string: %s\n",
+                    __FILE__, __LINE__, p);
+                regfree(&par);
+                goto error;
+            }
+        }
+        else if(config_setting_type(partitions) == CONFIG_TYPE_INT)
+        {
+            const int32_t value = config_setting_get_int(partitions);
+            if(value < 0)
+            {
+                fprintf(stderr, "%s %d: partitions must be a positive integer!\n",
+                    __FILE__, __LINE__);
+                goto error;
+            }
+            config_setting_remove(config, "partitions");
+
+            partitions = config_setting_add(config, "partitions", CONFIG_TYPE_STRING);
+            if(!partitions)
+            {
+                fprintf(stderr, "%s %d: failed to alloc config setting!\n",
+                    __FILE__, __LINE__);
+                abort();
+            }
+
+            char buf[512];
+            snprintf(buf,sizeof(buf), "%d", value);
+            config_setting_set_string(partitions, buf);
+        }
+        else
+        {
+            fprintf(stderr, "%s %d: partitions is of unknown type\n",
+                __FILE__, __LINE__);
+            goto error;
+        }
+    }
 
     return true;
+
+    error:
+    regfree(&top_par);
+    return false;
 }
 
 bool
@@ -510,9 +804,18 @@ bool
 kafka_consumer_validator(config_setting_t *config)
 {
     const char *groupid = NULL;
+    /*
     if(!CONF_L_IS_STRING(config, "groupid", &groupid,
         "kafka: consumer needs a group!"))
         return false;
+    */
+    if(config_setting_lookup_string(config, "groupid", &groupid) != CONFIG_TRUE)
+    {
+        fprintf(stderr, "%s %d: Warning: No groupid found. Disabling"
+            " high level consumer!\n", __FILE__, __LINE__);
+        config_set_default_string(config, "kafka_options/enable_auto_commit",
+            "false");
+    }
 
     return kafka_validator(config);
 }

--- a/src/kafka.h
+++ b/src/kafka.h
@@ -18,6 +18,7 @@ Consumer kafka_consumer_init(config_setting_t *config);
 void kafka_consumer_free(Consumer *c);
 
 int kafka_consumer_consume(Consumer c, Message msg);
+int kafka_simple_consumer_consume(Consumer c, Message msg);
 
 Validator kafka_validator_init();
 


### PR DESCRIPTION
Work in progress.

This new consumer mode allows to consume specific kafka partitions.
The syntax is like this:
```
     schaufel -i k -b kafka.broker.local -t topic.name.kind:0-15,20,25
```
The simple consumer will disable offset storage.

I haven't implemented the simple producer yet.