### PR TITLE
file: abort early on error in file producer

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -58,8 +58,14 @@ file_producer_produce(Producer p, Message msg)
 {
     char *line = message_get_data(msg);
     size_t len = message_get_len(msg);
+    size_t nmemb = sizeof(*line);
+    size_t ret;
 
-    fwrite(line, len, sizeof(*line),((Meta) p->meta)->fp);
+    ret = fwrite(line, len, nmemb, ((Meta) p->meta)->fp);
+    if (ret < nmemb) {
+        logger_log("%s %d: %s", __FILE__, __LINE__, strerror(errno));
+        abort();
+    }
 }
 
 void


### PR DESCRIPTION
Before:
```
% yes | ./schaufel -c1 -p1 -if -of -f/dev/stdin -F/dev/full
Mon Nov 21 15:37:54 2022 logger initialized
Mon Nov 21 15:37:54 2022 waiting for producer to come up
Mon Nov 21 15:37:55 2022 producer are up
Mon Nov 21 15:37:59 2022 added / s: 0 delivered / s: 0
Mon Nov 21 15:38:04 2022 added / s: 1081091 delivered / s: 1081091
Mon Nov 21 15:38:09 2022 added / s: 1507214 delivered / s: 1507214
Mon Nov 21 15:38:14 2022 added / s: 1378029 delivered / s: 1378029
Mon Nov 21 15:38:19 2022 added / s: 1382260 delivered / s: 1382041
Mon Nov 21 15:38:24 2022 added / s: 1316295 delivered / s: 1316514
^CMon Nov 21 15:38:26 2022 received signal to stop
Mon Nov 21 15:38:29 2022 added / s: 1209423 delivered / s: 1209423
Mon Nov 21 15:38:36 2022 file.c 37: No space left on device
Mon Nov 21 15:38:36 2022 done
```

After:
```
% yes | ./schaufel -c1 -p1 -if -of -f/dev/stdin -F/dev/full
Mon Nov 21 15:40:28 2022 logger initialized
Mon Nov 21 15:40:28 2022 waiting for producer to come up
Mon Nov 21 15:40:29 2022 producer are up
Mon Nov 21 15:40:29 2022 file.c 66: No space left on device
zsh: broken pipe          yes |
zsh: abort (core dumped)  ./schaufel -c1 -p1 -if -of -f/dev/stdin
-F/dev/full
```