### PR TITLE
file: warn & exit on filename not given

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -133,6 +133,14 @@ file_validate(config_setting_t* config)
         return false;
     }
 
+    const char *fname = NULL;
+    config_setting_lookup_string(config, "file", &fname);
+
+    if (!fname || !*fname) {
+        fprintf(stderr, "file consumer/producer needs a valid filename!\n");
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Fixes: #107

Before:
```
% ./schaufel -c1 -p1 -if -of
Thu Nov 24 09:45:20 2022 logger initialized
Thu Nov 24 09:45:20 2022 file.c 27: (null) Bad address
zsh: abort (core dumped)  ./schaufel -c1 -p1 -if -of
```

After:
```
% ./schaufel -c1 -p1 -if -of
file consumer/producer needs a valid filename!
file consumer/producer needs a valid filename!
usage
 ...
```