### PR TITLE
Postgresql: Handle copy errors

### DIFF
--- a/src/exports.c
+++ b/src/exports.c
@@ -633,7 +633,7 @@ exports_producer_produce(Producer p, Message msg)
             abort();
         }
         PQclear(m->res);
-        PQputCopyData(m->conn_master,
+        xPQputCopyData(m->conn_master,
             "PGCOPY\n\377\r\n\0" //postgres magic
             "\0\0\0\0"  // flags field (only bit 16 relevant)
             "\0\0\0\0"  // Header extension area
@@ -658,16 +658,16 @@ exports_producer_produce(Producer p, Message msg)
         goto fail;
     }
 
-    PQputCopyData(m->conn_master, (char *) &rows, 2);
+    xPQputCopyData(m->conn_master, (char *) &rows, 2);
 
     for (int i = 0; i < internal->ncount; i++) {
         if(!needles[i]->store)
             continue;
         uint32_t length =  htobe32(needles[i]->length);
-        PQputCopyData(m->conn_master, (void *) &length, 4);
+        xPQputCopyData(m->conn_master, (void *) &length, 4);
 
         if(needles[i]->result) {
-            PQputCopyData(m->conn_master, needles[i]->result, needles[i]->length);
+            xPQputCopyData(m->conn_master, needles[i]->result, needles[i]->length);
             needles[i]->free(&needles[i]->result);
         }
     }

--- a/src/postgres.c
+++ b/src/postgres.c
@@ -270,8 +270,8 @@ postgres_producer_produce(Producer p, Message msg)
         }
         PQclear(m->res);
 
-        if(m->cpyfmt  == POSTGRES_BINARY)
-            PQputCopyData(m->conn_master, binheader, 19);
+        if (m->cpyfmt == POSTGRES_BINARY)
+            xPQputCopyData(m->conn_master, binheader, 19);
 
         if (m->conninfo_replica)
         {
@@ -283,8 +283,8 @@ postgres_producer_produce(Producer p, Message msg)
             }
             PQclear(m->res);
 
-            if(m->cpyfmt  == POSTGRES_BINARY)
-                PQputCopyData(m->conn_replica, binheader, 19);
+            if (m->cpyfmt == POSTGRES_BINARY)
+                xPQputCopyData(m->conn_replica, binheader, 19);
         }
         m->copy = 1;
     }
@@ -292,28 +292,28 @@ postgres_producer_produce(Producer p, Message msg)
     if (m->cpyfmt != POSTGRES_BINARY) {
         if (lit[0] == ' ' && lit[1] == 'E')
         {
-            PQputCopyData(m->conn_master, lit + 3, strlen(lit) - 4);
+            xPQputCopyData(m->conn_master, lit + 3, strlen(lit) - 4);
             if (m->conninfo_replica)
-                PQputCopyData(m->conn_replica, lit + 3, strlen(lit) - 4);
+                xPQputCopyData(m->conn_replica, lit + 3, strlen(lit) - 4);
         }
         else if (lit[0] == '\'')
         {
-            PQputCopyData(m->conn_master, lit + 1, strlen(lit) - 2);
+            xPQputCopyData(m->conn_master, lit + 1, strlen(lit) - 2);
             if (m->conninfo_replica)
-                PQputCopyData(m->conn_replica, lit + 1, strlen(lit) - 2);
+                xPQputCopyData(m->conn_replica, lit + 1, strlen(lit) - 2);
         }
         else
             abort();
 
-        PQputCopyData(m->conn_master, newline, 1);
+        xPQputCopyData(m->conn_master, newline, 1);
 
         if (m->conninfo_replica)
-            PQputCopyData(m->conn_replica, newline, 1);
+            xPQputCopyData(m->conn_replica, newline, 1);
     } else {
-       PQputCopyData(m->conn_master, buf, len);
+       xPQputCopyData(m->conn_master, buf, len);
 
        if (m->conninfo_replica)
-           PQputCopyData(m->conn_replica, buf, len);
+           xPQputCopyData(m->conn_replica, buf, len);
     }
 
     m->count = m->count + 1;

--- a/src/utils/postgres.c
+++ b/src/utils/postgres.c
@@ -46,10 +46,10 @@ void
 commit(Meta *m)
 {
     if((*m)->cpyfmt == PQ_COPY_BINARY)
-        PQputCopyData((*m)->conn_master, "\377\377", 2);
-    PQputCopyEnd((*m)->conn_master, NULL);
+        xPQputCopyData((*m)->conn_master, "\377\377", 2);
+    xPQputCopyEnd((*m)->conn_master, NULL);
     if ((*m)->conninfo_replica)
-        PQputCopyEnd((*m)->conn_replica, NULL);
+        xPQputCopyEnd((*m)->conn_replica, NULL);
 
     (*m)->count = 0;
     (*m)->copy  = 0;

--- a/src/utils/postgres.h
+++ b/src/utils/postgres.h
@@ -26,6 +26,8 @@ typedef struct Meta {
     Internal        internal;
 } *Meta;
 
+void xPQputCopyData(PGconn *conn, const char *buffer, int nbytes);
+
 void commit(Meta *m);
 
 void *commit_worker(void *meta);


### PR DESCRIPTION
This is a relatively small change which ensures we handle libpq errors whilst `COPY`ing data and abort in case any error occurs. This partially fixes #80 which is a partial aid against data loss where we lose at most one batch of data in case of errors on postgresql side. The batch size is [hardcoded to 2000](https://github.com/adjust/schaufel/blob/00764c1d92c1a2dbdb9c7b6d6f01e3a325f38730/src/postgres.c#L320) at the moment. The second part of the issue where we ensure to retain messages in case of a libpq error is left to be fixed in a future PR.