### PR TITLE
src/utils/postgres.h: define commit interval in metadata

### DIFF
--- a/src/utils/postgres.h
+++ b/src/utils/postgres.h
@@ -20,6 +20,7 @@ typedef struct Meta {
     int             cpyfmt;
     int             count;
     int             copy;
+    int             commit_interval;
     int             commit_iter;
     pthread_mutex_t commit_mutex;
     pthread_t       commit_worker;


### PR DESCRIPTION
Previously we had the commit interval hardcoded to 2000 in postgres producer. It is useful to make this configurable for cases where data resiliency is more important than performance.

This commit introduces no functionality change as long as commit_interval is not specified in schaufel configuration. In this case, the default is unchanged and we commit once every 2000 messages.

Ref: #111