### PR TITLE
Add a container image and publish it on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+.git
+.github
+.gitignore
+
+# build artifacts -- host builds must not leak into the image
+obj/
+bin/
+doc/*.pdf
+schaufel-*-*-*/
+*.o
+*.deb
+*.buildinfo
+*.changes
+
+# autotools output
+autom4te.cache/
+Makefile.in
+aclocal.m4
+config.h.in
+config.log
+config.status
+configure
+build-aux/
+
+# local test configs (root level only; doc/*.conf is kept)
+*.conf

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -112,3 +112,75 @@ jobs:
             schaufel_*.deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-image:
+    needs: build-deb-gcc
+    name: Container image
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      # only the upstream repository publishes, and only for a release:
+      # workflow_dispatch and forks build without pushing
+      PUBLISH: ${{ github.event_name == 'release' && github.repository == 'adjust/schaufel' }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Read package version
+        id: version
+        run: |
+          version="$(sed -n 's/^SCHAUFEL_VERSION[[:space:]]*?=[[:space:]]*//p' Makefile)"
+          if [[ -z "${version}" ]]; then
+              echo "could not read SCHAUFEL_VERSION from Makefile" >&2
+              exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "image version: ${version}"
+
+      # the image must carry the same version as the deb packages, which take
+      # it from SCHAUFEL_VERSION in the Makefile
+      - name: Verify release tag matches package version
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [[ "${RELEASE_TAG#v}" != "${PACKAGE_VERSION}" ]]; then
+              echo "release tag '${RELEASE_TAG}' does not match SCHAUFEL_VERSION" \
+                  "'${PACKAGE_VERSION}' in the Makefile" >&2
+              exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ${{ env.REGISTRY }}
+        if: env.PUBLISH == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          # a single platform without attestations is pushed as a plain image
+          # manifest, which every runtime can pull
+          provenance: false
+          sbom: false
+          push: ${{ env.PUBLISH == 'true' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=MIT

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ stamp-h1
 src/schaufel
 /t/*
 !/t/*.c
+
+# local configs (doc/*.conf and sample/ are tracked)
+/*.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# The target platform is selected by the build, not here: a constant
+# FROM --platform= pins the base image without setting the platform of the
+# resulting manifest, which leaves the image advertising the platform it was
+# built on.
+FROM ubuntu:24.04 AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# libpq-dev is needed (not just libpq5): the Makefile calls pg_config --includedir
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        build-essential \
+        clang \
+        make \
+        pkg-config \
+        libconfig-dev \
+        libhiredis-dev \
+        libjson-c-dev \
+        libpq-dev \
+        librdkafka-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CC=clang
+ENV CFLAGS=-O2
+
+WORKDIR /opt/src
+COPY . .
+
+RUN make clean_release && make
+
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# runtime libraries only, mirroring the Depends: in debian/control
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        libconfig9 \
+        libhiredis1.1.0 \
+        libjson-c5 \
+        libpq5 \
+        librdkafka1 && \
+    rm -rf /var/lib/apt/lists/*
+
+# fixed uid/gid so mounted config/state volumes have predictable ownership
+# (the deb intentionally uses a dynamic uid; containers need a known one)
+RUN groupadd --system --gid 999 schaufel && \
+    useradd --system --uid 999 --gid schaufel --no-create-home \
+        --home-dir /var/lib/schaufel --shell /usr/sbin/nologin schaufel && \
+    mkdir -p /etc/schaufel /var/lib/schaufel && \
+    chown schaufel:schaufel /etc/schaufel /var/lib/schaufel
+
+COPY --from=builder /opt/src/bin/schaufel /usr/local/bin/schaufel
+COPY --from=builder /opt/src/doc/ /usr/share/doc/schaufel/
+
+ENV CONFIG_FILE=/etc/schaufel/schaufel.conf
+
+USER schaufel
+WORKDIR /var/lib/schaufel
+
+# Mount your config over CONFIG_FILE; see /usr/share/doc/schaufel/schaufel.conf
+# for a reference. Set the logger type to "stdout" so output reaches the
+# container log instead of a file.
+CMD exec /usr/local/bin/schaufel -C "${CONFIG_FILE}"


### PR DESCRIPTION
schaufel is built in a multi-stage image based on Ubuntu 24.04. The builder installs the dependencies listed in the README and runs the Makefile based build; the runtime stage only carries the libraries from debian/control's Depends, so no headers, static libraries or pg_config end up in the published image. It runs as a non-root schaufel user with a fixed uid/gid so mounted volumes have predictable ownership, and expects the config to be mounted over CONFIG_FILE. doc/*.conf ships as a reference; the logger type should be set to stdout so output reaches the container log.

The image is built from the same release event as the deb packages and pushed to ghcr.io, tagged with SCHAUFEL_VERSION from the Makefile so image and package versions cannot diverge - the job fails if the release tag disagrees with it. Pushing is limited to releases of adjust/schaufel, so workflow_dispatch runs and forks build the image without publishing anything. The GHCR package is created private and needs to be made public once after the first push.

Only amd64 is built for now. The platform is selected by the build rather than pinned with `FROM --platform=`: a constant pin only selects the base image and leaves the resulting manifest advertising the platform the image was built on, which container runtimes then refuse to pull. Attestations are disabled so a single platform image is pushed as a plain manifest. Adding arm64 is a small change if that's wanted.

Tested locally: the binary reports 0.12.2, all libraries resolve, it runs as uid 999, and the file to file test from test-pr.yml round-trips with a matching diff. The image has also been run on Kubernetes from ECR, shovelling to Kafka.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
